### PR TITLE
docs(test): Pytest guide and snowflake_e2e marker for fast local runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,16 +289,24 @@ uv run python docs/build_docs.py serve
 
 ### Running Tests
 
+For **local development**, prefer excluding live **Snowflake E2E** tests (they need credentials and dominate runtime). For **pre-merge** or Snowflake-related changes, run the full suite when you can.
+
 ```bash
-# Run all tests
-uv run pytest
+# Recommended default (fast; no Snowflake config required)
+uv run pytest tests/ -m "not snowflake_e2e"
 
-# Run with verbose output
+# Full suite including Snowflake E2E (slow; needs credentials)
+uv run pytest tests/
+
+# Verbose or pattern filtering
 uv run pytest tests/ -v
-
-# Run specific test patterns
 uv run pytest tests/ -k test_name
+
+# Faster iteration (disables default coverage from pyproject.toml)
+uv run pytest tests/ -m "not snowflake_e2e" --no-cov
 ```
+
+Details, markers, coverage defaults, and CI: **[tests/README.md](tests/README.md)**.
 
 ## 🤝 Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ Welcome to the Tee for Transform (t4t) documentation. t4t is a powerful Python f
 ### 🛠️ Development
 - [Architecture](development/architecture.md) - System design and components
 - [Contributing](development/contributing.md) - How to contribute to t4t
+- [Running the pytest suite](https://github.com/francescomucio/tee-for-transform/blob/main/tests/README.md) - Markers, Snowflake E2E, coverage, CI notes (source: `tests/README.md` in the repo)
 - [Migration Guides](development/migration-guides/index.md) - Upgrading between versions
 
 ## Key Features

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -52,9 +52,19 @@ Branch naming conventions:
 
 ### 3. Run Tests
 
+Most day-to-day work should use the **fast suite**, which **excludes live Snowflake E2E** tests. Those tests connect to a real Snowflake warehouse, need credentials, and take **much longer** than everything else combined. Use the **full suite** (including Snowflake E2E) before merging or when you change Snowflake-specific code and need warehouse-level validation.
+
+See **[tests/README.md](../../tests/README.md)** for the full rationale, credential setup, and CI notes.
+
 ```bash
-# Run all tests
-uv run pytest
+# Default for local development (no Snowflake credentials required)
+uv run pytest tests/ -m "not snowflake_e2e"
+
+# Full suite including Snowflake E2E (requires tests/.snowflake_config.json or env vars; slow)
+uv run pytest tests/
+
+# Only Snowflake E2E (debugging Snowflake integration)
+uv run pytest tests/ -m snowflake_e2e
 
 # Run with coverage
 uv run pytest --cov=tee --cov-report=html

--- a/tests/README.md
+++ b/tests/README.md
@@ -137,7 +137,56 @@ Tests specific to database adapter implementations:
 
 ## Running Tests
 
-### Using the Test Runner
+### Prerequisites
+
+- Run commands from the **package root** (`tee-for-transform/`, next to `pyproject.toml`), not from a subfolder, so `testpaths = ["tests"]` and imports resolve as in CI.
+- Install dev dependencies: **`uv sync`** (includes pytest and pytest-cov).
+
+### Choosing what to run: with or without Snowflake E2E
+
+Some tests are tagged **`snowflake_e2e`**. They open a **live Snowflake** session (warehouse, network) and exercise end-to-end materialization and related flows. They are defined under `tests/adapters/snowflake/*_e2e.py` and in `tests/engine/integration/test_function_execution_snowflake.py` (see [Test Markers](#test-markers)).
+
+**Run without Snowflake E2E** (recommended default for local work):
+
+- Typical wall time is **tens of seconds** for the rest of the suite (without coverage); the Snowflake E2E portion alone is often **many minutes**.
+- Use this for everyday development, refactors, parser/engine/DuckDB work, and any change that does not need a real Snowflake warehouse to validate.
+- Works **without** Snowflake credentials; nothing in that subset requires `tests/.snowflake_config.json`.
+
+```bash
+uv run pytest tests/ -m "not snowflake_e2e"
+```
+
+Add `-v` for verbose output.
+
+**Coverage (default):** `[tool.pytest.ini_options] addopts` in `pyproject.toml` turns on **`--cov=tee`** and HTML output under **`htmlcov/`**. For a **faster** feedback loop, pass **`--no-cov`** (especially with the full suite).
+
+**Combining markers:** For the **leanest** local run (no Snowflake E2E and no tests marked `slow`), use:
+
+```bash
+uv run pytest tests/ -m "not snowflake_e2e and not slow" --no-cov
+```
+
+**Run the full suite including Snowflake E2E** when:
+
+- You changed **Snowflake adapter** code, Snowflake-specific SQL, or behavior covered only by those E2E tests.
+- You are doing a **final check before merge** or release and have credentials available.
+- Your **CI** job is allowed to use Snowflake secrets (often a dedicated workflow or branch).
+
+```bash
+uv run pytest tests/
+```
+
+Requires Snowflake configuration: use `tests/.snowflake_config.json` (gitignored) or environment variables such as `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER`, and `SNOWFLAKE_PASSWORD` (see the Snowflake E2E modules under `tests/adapters/snowflake/` for details).
+
+**Run only Snowflake E2E** when you are **debugging Snowflake-specific** failures or iterating on those modules:
+
+```bash
+uv run pytest tests/ -m snowflake_e2e -v
+```
+
+### Using the Test Runner (`run_incremental_tests.py`)
+
+The script **`tests/run_incremental_tests.py`** is an **optional** helper that runs **pytest on a subset** of the tree (mostly incremental engine, adapter interface, DuckDB, performance). It does **not** replace **`uv run pytest tests/`** for full coverage of the project. Use it when you are focused on incremental materialization code paths; use full pytest for CLI, parser, importer, and the rest.
 
 ```bash
 # Run all incremental tests
@@ -164,10 +213,22 @@ uv run python tests/run_incremental_tests.py specific --test-path tests/engine/i
 
 ### Using pytest directly
 
+The commands above are summarized here for quick copy-paste:
+
 ```bash
-# Run all tests
+# Recommended default: full suite except Snowflake E2E
+uv run pytest tests/ -m "not snowflake_e2e" -v
+
+# Everything including Snowflake E2E (requires tests/.snowflake_config.json or env vars)
 uv run pytest tests/ -v
 
+# Only Snowflake E2E
+uv run pytest tests/ -m snowflake_e2e -v
+```
+
+Other useful invocations:
+
+```bash
 # Run specific test file
 uv run pytest tests/engine/incremental/test_should_run.py -v
 
@@ -188,7 +249,17 @@ uv run pytest tests/ -m integration -v
 
 # Skip slow tests
 uv run pytest tests/ -m "not slow" -v
+
+# Stop on first failure
+uv run pytest tests/ -x
+
+# Shorter tracebacks
+uv run pytest tests/ --tb=short
 ```
+
+### Parallel execution
+
+Parallel test runs (**pytest-xdist**, e.g. `-n auto`) are **not** wired into this repo by default. They can speed up some suites but are not required; start with **`--no-cov`** before adding workers.
 
 ## Test Markers
 
@@ -197,6 +268,7 @@ Tests are marked with categories for easy filtering:
 - `@pytest.mark.unit`: Unit tests (fast, isolated)
 - `@pytest.mark.integration`: Integration tests (require database)
 - `@pytest.mark.slow`: Performance tests (may take longer)
+- `@pytest.mark.snowflake_e2e`: Live Snowflake end-to-end tests (applied in `conftest.py` to `tests/adapters/snowflake/*_e2e.py` and `tests/engine/integration/test_function_execution_snowflake.py`). For when to exclude them, see [Choosing what to run](#choosing-what-to-run-with-or-without-snowflake-e2e).
 
 ## Test Fixtures
 
@@ -356,7 +428,8 @@ Tests are designed to run in CI environments:
 - No external dependencies beyond test databases
 - Temporary files are cleaned up automatically
 - Tests are marked for different execution environments
-- Performance tests can be skipped in fast CI runs
+- Performance tests can be skipped in fast CI runs (`-m "not slow"`)
+- **Snowflake E2E** often need secrets and significant time; many pipelines run **`pytest -m "not snowflake_e2e"`** on every push and reserve the full suite (or a scheduled job) for environments with Snowflake credentials
 
 ## Debugging Tests
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,10 @@ def pytest_configure(config):
     )
     config.addinivalue_line("markers", "integration: marks tests as integration tests")
     config.addinivalue_line("markers", "unit: marks tests as unit tests")
+    config.addinivalue_line(
+        "markers",
+        'snowflake_e2e: live Snowflake E2E; exclude with -m "not snowflake_e2e" for fast local runs',
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -195,6 +199,14 @@ def pytest_collection_modifyitems(config, items):
             or "test_incremental_performance.py" in str(item.fspath)
         ):
             item.add_marker(pytest.mark.slow)
+
+        # Live Snowflake E2E (network + warehouse): exclude from default fast local runs
+        fp = str(item.fspath)
+        if (
+            ("adapters/snowflake/" in fp and "_e2e.py" in fp)
+            or "test_function_execution_snowflake.py" in fp
+        ):
+            item.add_marker(pytest.mark.snowflake_e2e)
 
     # Remove items that shouldn't be collected as tests
     for item in items_to_remove:


### PR DESCRIPTION
## Summary

- Add `snowflake_e2e` pytest marker (applied in `tests/conftest.py`) for live Snowflake E2E tests so the rest of the suite can be run with `-m "not snowflake_e2e"` (~tens of seconds vs many minutes with Snowflake).
- Document **when** to use the fast suite vs full suite vs Snowflake-only, **prerequisites** (`uv sync`, run from package root), **coverage** (`addopts` vs `--no-cov`), **marker combinations** (`not snowflake_e2e and not slow`), how `run_incremental_tests.py` relates to full pytest, CI notes, and a short note on parallel (`pytest-xdist`) not being configured by default.

## Files

- `tests/conftest.py` — marker registration and collection hook
- `tests/README.md` — main testing guide (expanded)
- `docs/development/contributing.md`, `docs/README.md`, `README.md` — pointers and quick commands

Related context: GitHub issue discussion on core vs full test runs (#16).

Made with [Cursor](https://cursor.com)