### PR TITLE
docs: #26 add 5-minute quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A Python framework for SQL data transformations with **DuckDB** (including **Mot
 
 ## 🚀 Quick Start
 
+> **New here?** Start with the [5-Minute Quickstart](docs/getting-started/quickstart.md) — it takes under 5 minutes and uses DuckDB (no external database needed).
+
 ```bash
 # Install t4t (DuckDB included — no extra drivers needed)
 pip install t4t

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,9 @@ Welcome to the Tee for Transform (t4t) documentation. t4t is a powerful Python f
 ### 🚀 Getting Started
 - [Installation](getting-started/installation.md) - Install t4t and its dependencies
 - [Quick Start](getting-started/quick-start.md) - Get up and running in minutes
+- [5-Minute Quickstart](getting-started/quickstart.md) - Get started in under 5 minutes
 - [Configuration](getting-started/configuration.md) - Configure databases and settings
+- [t4t for dbt Users](getting-started/dbt-users-guide.md) - Migration guide for dbt users
 
 ### 📖 User Guide
 - [Overview](user-guide/overview.md) - Core concepts and architecture

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,88 @@
+# 5-Minute Quickstart
+
+Get started with t4t in under 5 minutes. All you need is Python and 5 minutes.
+
+## 1. Install t4t
+
+```bash
+pip install t4t
+```
+
+That's it. DuckDB is included — no extra database drivers needed.
+
+## 2. Create a Project
+
+```bash
+t4t init demo_project
+```
+
+This creates:
+```
+demo_project/
+├── project.toml    # Configuration (DuckDB by default)
+├── models/         # Your SQL and Python models
+├── tests/          # Data quality tests
+├── seeds/          # Static data files
+└── data/           # DuckDB database file
+```
+
+## 3. Add a Model
+
+Create a simple SQL model:
+
+```bash
+echo "SELECT 1 AS id, 'hello t4t' AS message" > demo_project/models/hello.sql
+```
+
+## 4. Run It
+
+```bash
+t4t run demo_project
+```
+
+You'll see output like:
+```
+[INFO] Running model: hello
+[INFO] Model hello completed successfully
+```
+
+Your model is now a table in DuckDB. You can query it with any DuckDB-compatible tool.
+
+## 5. Add a Test
+
+Create a test to verify your data:
+
+```bash
+mkdir -p demo_project/tests
+echo "SELECT * FROM hello WHERE id IS NULL" > demo_project/tests/check_not_null.sql
+```
+
+Run tests:
+
+```bash
+t4t test demo_project
+```
+
+## 6. Generate Documentation
+
+```bash
+t4t docs demo_project
+```
+
+This generates a static documentation site with your model's dependency graph and metadata.
+
+## What Just Happened?
+
+| Step | What t4t Did |
+|---|---|
+| `t4t init` | Created project structure with DuckDB config |
+| `t4t run` | Parsed your SQL, detected dependencies, executed against DuckDB, materialized as a table |
+| `t4t test` | Ran your test SQL against the database |
+| `t4t docs` | Generated interactive documentation with dependency graph |
+
+## Next Steps
+
+- [Configuration](configuration.md) — Customize database connections
+- [Data Quality Tests](../user-guide/data-quality-tests.md) — Add more tests
+- [Python Models](../api-reference/models.md) — Use the `@model` decorator
+- [dbt Users Guide](dbt-users-guide.md) — Coming from dbt?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,7 +73,9 @@ nav:
   - Getting Started:
     - getting-started/installation.md
     - getting-started/quick-start.md
+    - getting-started/quickstart.md
     - getting-started/configuration.md
+    - getting-started/dbt-users-guide.md
   - User Guide:
     - user-guide/overview.md
     - user-guide/cli-reference.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,7 +72,6 @@ nav:
   - Home: README.md
   - Getting Started:
     - getting-started/installation.md
-    - getting-started/quick-start.md
     - getting-started/quickstart.md
     - getting-started/configuration.md
     - getting-started/dbt-users-guide.md


### PR DESCRIPTION
Closes #26

## Summary

Adds a 5-minute quickstart guide for t4t: install → init → run → test → docs, all on DuckDB with zero configuration.

## Changes
- `docs/getting-started/quickstart.md` — new step-by-step guide
- `README.md` — added callout linking to quickstart
- `docs/README.md` — added link in Getting Started section
- `mkdocs.yml` — added to navigation