### PR TITLE
feat: first-class environments in project.toml ([environments.*]) — #27

### DIFF
--- a/t4t/cli/context.py
+++ b/t4t/cli/context.py
@@ -46,6 +46,12 @@ class CommandContext:
         # Load project configuration
         self.config = load_project_config(project_folder, self.vars, self.env)
 
+        # If no env was explicitly provided, check for default_environment in config
+        if self.env is None and "default_environment" in self.config:
+            self.env = self.config["default_environment"]
+            # Reload config with the default environment
+            self.config = load_project_config(project_folder, self.vars, self.env)
+
         # Set up logging
         self.verbose = verbose
         setup_logging(self.verbose)

--- a/t4t/cli/context.py
+++ b/t4t/cli/context.py
@@ -24,6 +24,7 @@ class CommandContext:
         verbose: bool = False,
         select: list[str] | None = None,
         exclude: list[str] | None = None,
+        env: str | None = None,
     ) -> None:
         """
         Initialize command context from parameters.
@@ -34,12 +35,16 @@ class CommandContext:
             verbose: Enable verbose output
             select: Selection patterns
             exclude: Exclusion patterns
+            env: Optional environment name to use
         """
         # Parse variables if provided
         self.vars = parse_vars(vars)
 
+        # Store environment name
+        self.env = env
+
         # Load project configuration
-        self.config = load_project_config(project_folder, self.vars)
+        self.config = load_project_config(project_folder, self.vars, self.env)
 
         # Set up logging
         self.verbose = verbose

--- a/t4t/cli/utils.py
+++ b/t4t/cli/utils.py
@@ -66,36 +66,24 @@ def load_project_config(
     if "project_folder" not in config:
         raise ValueError("project.toml must contain 'project_folder' setting")
 
-    # If env_name is specified, load connection from [environments.<env_name>]
+    # If no env_name specified, check for default_environment
+    if env_name is None and "default_environment" in config:
+        env_name = config["default_environment"]
+
+    # If env_name is specified, delegate to DatabaseConfigManager._resolve_environment
     if env_name is not None:
-        environments = config.get("environments", {})
-        if not isinstance(environments, dict) or env_name not in environments:
-            available = (
-                ", ".join(sorted(environments.keys())) if isinstance(environments, dict) else ""
-            )
-            msg = f"Unknown environment '{env_name}'"
-            if available:
-                msg += f". Available environments: {available}"
-            raise ValueError(msg)
+        from t4t.engine.config import DatabaseConfigManager
 
-        env_section = environments[env_name]
-        if not isinstance(env_section, dict):
-            raise ValueError(f"Environment '{env_name}' must be a table section")
-
-        # Load connection from [environments.<name>].connection
-        env_connection = env_section.get("connection", {})
-        if isinstance(env_connection, dict):
-            config["connection"] = env_connection
+        env_connection, env_variables, _protected = DatabaseConfigManager._resolve_environment(
+            config, env_name
+        )
+        config["connection"] = env_connection
 
         # Merge env-level variables with CLI vars (CLI wins)
-        env_variables = env_section.get("variables", {})
-        if isinstance(env_variables, dict):
-            merged_vars = dict(env_variables)
-            if vars_dict:
-                merged_vars.update(vars_dict)
-            config["vars"] = merged_vars
-        elif vars_dict:
-            config["vars"] = vars_dict
+        merged_vars = dict(env_variables)
+        if vars_dict:
+            merged_vars.update(vars_dict)
+        config["vars"] = merged_vars
     else:
         # Legacy mode: require [connection]
         if "connection" not in config:

--- a/t4t/cli/utils.py
+++ b/t4t/cli/utils.py
@@ -33,7 +33,9 @@ def parse_vars(vars_string: str | None) -> dict[str, Any]:
 
 
 def load_project_config(
-    project_folder: str, vars_dict: dict[str, Any] | None = None
+    project_folder: str,
+    vars_dict: dict[str, Any] | None = None,
+    env_name: str | None = None,
 ) -> dict[str, Any]:
     """
     Load project configuration from project.toml file and merge with variables.
@@ -41,9 +43,13 @@ def load_project_config(
     Args:
         project_folder: Path to the project folder
         vars_dict: Optional dictionary of variables to merge into config
+        env_name: Optional environment name to load connection from [environments.<name>]
 
     Returns:
         Dictionary containing project configuration with variables merged
+
+    Raises:
+        ValueError: If the environment name is unknown
     """
     project_toml_path = Path(project_folder) / "project.toml"
 
@@ -60,12 +66,44 @@ def load_project_config(
     if "project_folder" not in config:
         raise ValueError("project.toml must contain 'project_folder' setting")
 
-    if "connection" not in config:
-        raise ValueError("project.toml must contain 'connection' configuration")
+    # If env_name is specified, load connection from [environments.<env_name>]
+    if env_name is not None:
+        environments = config.get("environments", {})
+        if not isinstance(environments, dict) or env_name not in environments:
+            available = (
+                ", ".join(sorted(environments.keys())) if isinstance(environments, dict) else ""
+            )
+            msg = f"Unknown environment '{env_name}'"
+            if available:
+                msg += f". Available environments: {available}"
+            raise ValueError(msg)
 
-    # Merge variables into config
-    if vars_dict:
-        config["vars"] = vars_dict
+        env_section = environments[env_name]
+        if not isinstance(env_section, dict):
+            raise ValueError(f"Environment '{env_name}' must be a table section")
+
+        # Load connection from [environments.<name>].connection
+        env_connection = env_section.get("connection", {})
+        if isinstance(env_connection, dict):
+            config["connection"] = env_connection
+
+        # Merge env-level variables with CLI vars (CLI wins)
+        env_variables = env_section.get("variables", {})
+        if isinstance(env_variables, dict):
+            merged_vars = dict(env_variables)
+            if vars_dict:
+                merged_vars.update(vars_dict)
+            config["vars"] = merged_vars
+        elif vars_dict:
+            config["vars"] = vars_dict
+    else:
+        # Legacy mode: require [connection]
+        if "connection" not in config:
+            raise ValueError("project.toml must contain 'connection' configuration")
+
+        # Merge variables into config
+        if vars_dict:
+            config["vars"] = vars_dict
 
     return config
 

--- a/t4t/engine/config.py
+++ b/t4t/engine/config.py
@@ -21,12 +21,15 @@ class DatabaseConfigManager:
         self.project_root = Path(project_root) if project_root else Path.cwd()
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    def load_config(self, config_name: str = "default") -> AdapterConfig:
+    def load_config(
+        self, config_name: str = "default", env_name: str | None = None
+    ) -> AdapterConfig:
         """
         Load database configuration from pyproject.toml and environment variables.
 
         Args:
             config_name: Name of the configuration to load (default: "default")
+            env_name: Optional environment name to load from [environments.<name>]
 
         Returns:
             AdapterConfig object with merged configuration
@@ -35,7 +38,7 @@ class DatabaseConfigManager:
             ValueError: If configuration is invalid or missing
         """
         # Load from pyproject.toml
-        toml_config = self._load_toml_config(config_name)
+        toml_config = self._load_toml_config(config_name, env_name)
 
         # Load from environment variables
         env_config = self._load_env_config()
@@ -46,8 +49,16 @@ class DatabaseConfigManager:
         # Validate and create AdapterConfig
         return self._create_adapter_config(merged_config)
 
-    def _load_toml_config(self, config_name: str) -> dict[str, Any]:
-        """Load configuration from pyproject.toml or project.toml."""
+    def _load_toml_config(self, config_name: str, env_name: str | None = None) -> dict[str, Any]:
+        """Load configuration from pyproject.toml or project.toml.
+
+        Args:
+            config_name: Name of the database configuration (for legacy tool.t4t.databases)
+            env_name: Optional environment name to load from [environments.<name>]
+
+        Returns:
+            Dictionary containing the merged configuration
+        """
         # Try pyproject.toml first
         toml_file = self.project_root / "pyproject.toml"
         if not toml_file.exists():
@@ -65,9 +76,42 @@ class DatabaseConfigManager:
             t4t_config = data.get("tool", {}).get("t4t", {})
 
             # Start with flags if they exist
-            config = {}
+            config: dict[str, Any] = {}
             if "flags" in data:
                 config["extra"] = {"flags": data["flags"]}
+
+            # If an env_name is specified, look in [environments.<env_name>]
+            if env_name is not None:
+                environments = data.get("environments", {})
+                if not isinstance(environments, dict) or env_name not in environments:
+                    available = (
+                        ", ".join(sorted(environments.keys()))
+                        if isinstance(environments, dict)
+                        else ""
+                    )
+                    msg = f"Unknown environment '{env_name}'"
+                    if available:
+                        msg += f". Available environments: {available}"
+                    raise ValueError(msg)
+
+                env_section = environments[env_name]
+                if not isinstance(env_section, dict):
+                    raise ValueError(f"Environment '{env_name}' must be a table section")
+
+                # Load connection from [environments.<name>].connection
+                env_connection = env_section.get("connection", {})
+                if isinstance(env_connection, dict):
+                    config.update(env_connection)
+
+                # Load variables from [environments.<name>].variables
+                env_variables = env_section.get("variables", {})
+                if isinstance(env_variables, dict):
+                    config["_env_variables"] = env_variables
+
+                # Load protected flag
+                config["_protected"] = env_section.get("protected", False)
+
+                return config
 
             # Check for single database config in tool.t4t.database
             if "database" in t4t_config:
@@ -89,6 +133,8 @@ class DatabaseConfigManager:
             self.logger.debug(f"No database configuration '{config_name}' found in TOML file")
             return {}
 
+        except ValueError:
+            raise
         except Exception as e:
             self.logger.warning(f"Could not read pyproject.toml: {e}")
             return {}
@@ -169,7 +215,9 @@ class DatabaseConfigManager:
 
 
 def load_database_config(
-    config_name: str = "default", project_root: str | None = None
+    config_name: str = "default",
+    project_root: str | None = None,
+    env_name: str | None = None,
 ) -> AdapterConfig:
     """
     Convenience function to load database configuration.
@@ -177,9 +225,10 @@ def load_database_config(
     Args:
         config_name: Name of the configuration to load
         project_root: Project root directory (defaults to current directory)
+        env_name: Optional environment name to load from [environments.<name>]
 
     Returns:
         AdapterConfig object
     """
     manager = DatabaseConfigManager(project_root)
-    return manager.load_config(config_name)
+    return manager.load_config(config_name, env_name)

--- a/t4t/engine/config.py
+++ b/t4t/engine/config.py
@@ -49,6 +49,53 @@ class DatabaseConfigManager:
         # Validate and create AdapterConfig
         return self._create_adapter_config(merged_config)
 
+    @staticmethod
+    def _resolve_environment(
+        data: dict[str, Any], env_name: str
+    ) -> tuple[dict[str, Any], dict[str, Any], bool]:
+        """Resolve an environment section from TOML data.
+
+        Shared helper used by both DatabaseConfigManager and load_project_config.
+
+        Args:
+            data: The parsed TOML data dict
+            env_name: The environment name to resolve
+
+        Returns:
+            Tuple of (connection_dict, variables_dict, protected_flag)
+
+        Raises:
+            ValueError: If the environment name is unknown or not a table
+        """
+        environments = data.get("environments", {})
+        if not isinstance(environments, dict) or env_name not in environments:
+            available = (
+                ", ".join(sorted(environments.keys())) if isinstance(environments, dict) else ""
+            )
+            msg = f"Unknown environment '{env_name}'"
+            if available:
+                msg += f". Available environments: {available}"
+            raise ValueError(msg)
+
+        env_section = environments[env_name]
+        if not isinstance(env_section, dict):
+            raise ValueError(f"Environment '{env_name}' must be a table section")
+
+        # Load connection from [environments.<name>].connection
+        env_connection = env_section.get("connection", {})
+        if not isinstance(env_connection, dict):
+            env_connection = {}
+
+        # Load variables from [environments.<name>].variables
+        env_variables = env_section.get("variables", {})
+        if not isinstance(env_variables, dict):
+            env_variables = {}
+
+        # Load protected flag
+        protected = bool(env_section.get("protected", False))
+
+        return env_connection, env_variables, protected
+
     def _load_toml_config(self, config_name: str, env_name: str | None = None) -> dict[str, Any]:
         """Load configuration from pyproject.toml or project.toml.
 
@@ -82,35 +129,23 @@ class DatabaseConfigManager:
 
             # If an env_name is specified, look in [environments.<env_name>]
             if env_name is not None:
-                environments = data.get("environments", {})
-                if not isinstance(environments, dict) or env_name not in environments:
-                    available = (
-                        ", ".join(sorted(environments.keys()))
-                        if isinstance(environments, dict)
-                        else ""
-                    )
-                    msg = f"Unknown environment '{env_name}'"
-                    if available:
-                        msg += f". Available environments: {available}"
-                    raise ValueError(msg)
-
-                env_section = environments[env_name]
-                if not isinstance(env_section, dict):
-                    raise ValueError(f"Environment '{env_name}' must be a table section")
-
-                # Load connection from [environments.<name>].connection
-                env_connection = env_section.get("connection", {})
-                if isinstance(env_connection, dict):
-                    config.update(env_connection)
-
-                # Load variables from [environments.<name>].variables
-                env_variables = env_section.get("variables", {})
-                if isinstance(env_variables, dict):
+                env_connection, env_variables, protected = self._resolve_environment(data, env_name)
+                config.update(env_connection)
+                if env_variables:
                     config["_env_variables"] = env_variables
+                config["_protected"] = protected
+                return config
 
-                # Load protected flag
-                config["_protected"] = env_section.get("protected", False)
-
+            # If no env_name, check for default_environment
+            if "default_environment" in data:
+                default_env = data["default_environment"]
+                env_connection, env_variables, protected = self._resolve_environment(
+                    data, default_env
+                )
+                config.update(env_connection)
+                if env_variables:
+                    config["_env_variables"] = env_variables
+                config["_protected"] = protected
                 return config
 
             # Check for single database config in tool.t4t.database
@@ -193,6 +228,15 @@ class DatabaseConfigManager:
         # Map source_sql_dialect to source_dialect (source_sql_dialect is the preferred name in project.toml)
         source_dialect = config_dict.get("source_dialect") or config_dict.get("source_sql_dialect")
 
+        # Build extra dict, consuming _env_variables and _protected
+        extra: dict[str, Any] = {}
+        if config_dict.get("extra"):
+            extra.update(config_dict["extra"])
+        if config_dict.get("_env_variables"):
+            extra["env_variables"] = config_dict["_env_variables"]
+        if config_dict.get("_protected"):
+            extra["protected"] = config_dict["_protected"]
+
         # Create AdapterConfig
         return AdapterConfig(
             type=db_type,
@@ -210,7 +254,7 @@ class DatabaseConfigManager:
             warehouse=config_dict.get("warehouse"),
             role=config_dict.get("role"),
             project=config_dict.get("project"),
-            extra=config_dict.get("extra"),
+            extra=extra or None,
         )
 
 

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -1,0 +1,188 @@
+"""Tests for first-class environments in project.toml ([environments.*])."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from t4t.cli.utils import load_project_config
+from t4t.engine.config import DatabaseConfigManager
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def project_toml_with_environments():
+    """Create a project.toml with [environments.dev] and [environments.prod]."""
+    content = """
+project_folder = "my_project"
+default_environment = "dev"
+
+[environments.dev]
+[environments.dev.connection]
+type = "duckdb"
+path = "data/dev.duckdb"
+[environments.dev.variables]
+row_limit = 1000
+env_name = "dev"
+
+[environments.prod]
+protected = true
+[environments.prod.connection]
+type = "snowflake"
+database = "ANALYTICS"
+[environments.prod.variables]
+row_limit = 0
+env_name = "prod"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "project.toml"
+        path.write_text(content)
+        yield tmpdir
+
+
+@pytest.fixture
+def project_toml_legacy():
+    """Create a project.toml with legacy [connection] section."""
+    content = """
+project_folder = "my_project"
+
+[connection]
+type = "duckdb"
+path = "data/default.duckdb"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "project.toml"
+        path.write_text(content)
+        yield tmpdir
+
+
+@pytest.fixture
+def project_toml_no_environments():
+    """Create a project.toml with no environments and no connection."""
+    content = """
+project_folder = "my_project"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "project.toml"
+        path.write_text(content)
+        yield tmpdir
+
+
+# ---------------------------------------------------------------------------
+# Tests: load_project_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadProjectConfigEnvironments:
+    """Tests for load_project_config with [environments.*]."""
+
+    def test_legacy_connection_still_works(self, project_toml_legacy):
+        """Legacy [connection] section must keep working."""
+        config = load_project_config(project_toml_legacy)
+        assert config["connection"]["type"] == "duckdb"
+        assert config["connection"]["path"] == "data/default.duckdb"
+
+    def test_legacy_connection_with_vars(self, project_toml_legacy):
+        """Legacy [connection] with CLI vars."""
+        config = load_project_config(project_toml_legacy, vars_dict={"row_limit": 500})
+        assert config["connection"]["type"] == "duckdb"
+        assert config["vars"] == {"row_limit": 500}
+
+    def test_environment_dev(self, project_toml_with_environments):
+        """Load connection from [environments.dev]."""
+        config = load_project_config(project_toml_with_environments, env_name="dev")
+        assert config["connection"]["type"] == "duckdb"
+        assert config["connection"]["path"] == "data/dev.duckdb"
+
+    def test_environment_prod(self, project_toml_with_environments):
+        """Load connection from [environments.prod]."""
+        config = load_project_config(project_toml_with_environments, env_name="prod")
+        assert config["connection"]["type"] == "snowflake"
+        assert config["connection"]["database"] == "ANALYTICS"
+
+    def test_environment_variables_merged(self, project_toml_with_environments):
+        """Env-level variables are loaded."""
+        config = load_project_config(project_toml_with_environments, env_name="dev")
+        assert config["vars"]["row_limit"] == 1000
+        assert config["vars"]["env_name"] == "dev"
+
+    def test_environment_variables_cli_wins(self, project_toml_with_environments):
+        """CLI vars override env-level variables."""
+        config = load_project_config(
+            project_toml_with_environments,
+            env_name="dev",
+            vars_dict={"row_limit": 999, "cli_override": True},
+        )
+        # CLI value wins
+        assert config["vars"]["row_limit"] == 999
+        # Env-level var still present
+        assert config["vars"]["env_name"] == "dev"
+        # CLI-only var present
+        assert config["vars"]["cli_override"] is True
+
+    def test_unknown_environment_error(self, project_toml_with_environments):
+        """Unknown env name raises ValueError listing available envs."""
+        with pytest.raises(ValueError, match="Unknown environment 'nonexistent'"):
+            load_project_config(project_toml_with_environments, env_name="nonexistent")
+
+    def test_unknown_environment_lists_available(self, project_toml_with_environments):
+        """Error message lists available environments."""
+        with pytest.raises(ValueError, match="Available environments: dev, prod"):
+            load_project_config(project_toml_with_environments, env_name="nonexistent")
+
+    def test_legacy_missing_connection_error(self, project_toml_no_environments):
+        """Legacy mode without [connection] raises error."""
+        with pytest.raises(ValueError, match="project.toml must contain 'connection'"):
+            load_project_config(project_toml_no_environments)
+
+
+# ---------------------------------------------------------------------------
+# Tests: DatabaseConfigManager
+# ---------------------------------------------------------------------------
+
+
+class TestDatabaseConfigManagerEnvironments:
+    """Tests for DatabaseConfigManager with [environments.*]."""
+
+    def test_legacy_connection(self, project_toml_legacy):
+        """Legacy [connection] still works via DatabaseConfigManager."""
+        manager = DatabaseConfigManager(project_root=project_toml_legacy)
+        config = manager.load_config()
+        assert config.type == "duckdb"
+        assert config.path == "data/default.duckdb"
+
+    def test_environment_dev(self, project_toml_with_environments):
+        """Load from [environments.dev] via DatabaseConfigManager."""
+        manager = DatabaseConfigManager(project_root=project_toml_with_environments)
+        config = manager.load_config(env_name="dev")
+        assert config.type == "duckdb"
+        assert config.path == "data/dev.duckdb"
+
+    def test_environment_prod(self, project_toml_with_environments):
+        """Load from [environments.prod] via DatabaseConfigManager."""
+        manager = DatabaseConfigManager(project_root=project_toml_with_environments)
+        config = manager.load_config(env_name="prod")
+        assert config.type == "snowflake"
+        assert config.database == "ANALYTICS"
+
+    def test_unknown_environment_error(self, project_toml_with_environments):
+        """Unknown env name raises ValueError."""
+        manager = DatabaseConfigManager(project_root=project_toml_with_environments)
+        with pytest.raises(ValueError, match="Unknown environment 'bad'"):
+            manager.load_config(env_name="bad")
+
+    def test_unknown_environment_lists_available(self, project_toml_with_environments):
+        """Error message lists available environments."""
+        manager = DatabaseConfigManager(project_root=project_toml_with_environments)
+        with pytest.raises(ValueError, match="Available environments: dev, prod"):
+            manager.load_config(env_name="bad")
+
+    def test_no_toml_file(self):
+        """No TOML file returns empty config (no error)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = DatabaseConfigManager(project_root=tmpdir)
+            with pytest.raises(ValueError, match="No database configuration found"):
+                manager.load_config(env_name="dev")

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -138,6 +138,20 @@ class TestLoadProjectConfigEnvironments:
         with pytest.raises(ValueError, match="project.toml must contain 'connection'"):
             load_project_config(project_toml_no_environments)
 
+    def test_default_environment_used_when_no_env_specified(self, project_toml_with_environments):
+        """default_environment is used when no env is specified."""
+        config = load_project_config(project_toml_with_environments)
+        assert config["connection"]["type"] == "duckdb"
+        assert config["connection"]["path"] == "data/dev.duckdb"
+        assert config["vars"]["row_limit"] == 1000
+
+    def test_default_environment_overridden_by_explicit_env(self, project_toml_with_environments):
+        """Explicit env_name overrides default_environment."""
+        config = load_project_config(project_toml_with_environments, env_name="prod")
+        assert config["connection"]["type"] == "snowflake"
+        assert config["connection"]["database"] == "ANALYTICS"
+        assert config["vars"]["row_limit"] == 0
+
 
 # ---------------------------------------------------------------------------
 # Tests: DatabaseConfigManager
@@ -186,3 +200,23 @@ class TestDatabaseConfigManagerEnvironments:
             manager = DatabaseConfigManager(project_root=tmpdir)
             with pytest.raises(ValueError, match="No database configuration found"):
                 manager.load_config(env_name="dev")
+
+    def test_default_environment_via_manager(self, project_toml_with_environments):
+        """DatabaseConfigManager uses default_environment when no env_name given."""
+        manager = DatabaseConfigManager(project_root=project_toml_with_environments)
+        config = manager.load_config()
+        assert config.type == "duckdb"
+        assert config.path == "data/dev.duckdb"
+        # _env_variables and _protected should be in extra
+        assert config.extra is not None
+        assert config.extra.get("env_variables", {}).get("row_limit") == 1000
+
+    def test_default_environment_overridden_via_manager(self, project_toml_with_environments):
+        """Explicit env_name overrides default_environment in DatabaseConfigManager."""
+        manager = DatabaseConfigManager(project_root=project_toml_with_environments)
+        config = manager.load_config(env_name="prod")
+        assert config.type == "snowflake"
+        assert config.database == "ANALYTICS"
+        # protected flag should be in extra
+        assert config.extra is not None
+        assert config.extra.get("protected") is True


### PR DESCRIPTION
## Summary

Implements first-class environment support in project.toml via [environments.*] sections. Closes #27.

## Changes

- **t4t/engine/config.py**: DatabaseConfigManager with env_name parameter to load from [environments.<name>]
- **t4t/cli/utils.py**: load_project_config with env_name parameter
- **t4t/cli/context.py**: CommandContext with env parameter
- **tests/test_environments.py**: 15 new tests covering environments, legacy compat, and error cases

## Design

Environments are defined as TOML tables under [environments.<name>] with:
- [environments.<name>.connection] — database connection config
- [environments.<name>.variables] — env-specific variables
- protected — boolean flag for production environments

Legacy [connection] section continues to work when no --env is specified.