### PR TITLE
feat: add --env flag to all commands (+ T4T_ENV, RunManifest env) — #28

### DIFF
--- a/_create_pr.py
+++ b/_create_pr.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Create a PR for the environments feature branch."""
+
+import json
+import urllib.request
+
+with open("/opt/data/.github_token") as f:
+    token = f.read().strip()
+
+data = json.dumps(
+    {
+        "title": "feat: first-class environments in project.toml ([environments.*]) — #27",
+        "head": "feat/environments-in-project-toml",
+        "base": "main",
+        "body": (
+            "## Summary\n\n"
+            "Implements first-class environment support in project.toml via [environments.*] sections. Closes #27.\n\n"
+            "## Changes\n\n"
+            "- **t4t/engine/config.py**: DatabaseConfigManager with env_name parameter to load from [environments.<name>]\n"
+            "- **t4t/cli/utils.py**: load_project_config with env_name parameter\n"
+            "- **t4t/cli/context.py**: CommandContext with env parameter\n"
+            "- **tests/test_environments.py**: 15 new tests covering environments, legacy compat, and error cases\n\n"
+            "## Design\n\n"
+            "Environments are defined as TOML tables under [environments.<name>] with:\n"
+            "- [environments.<name>.connection] — database connection config\n"
+            "- [environments.<name>.variables] — env-specific variables\n"
+            "- protected — boolean flag for production environments\n\n"
+            "Legacy [connection] section continues to work when no --env is specified."
+        ),
+    }
+).encode()
+
+req = urllib.request.Request(
+    "https://api.github.com/repos/francescomucio/tee-for-transform/pulls",
+    data=data,
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "hermes-agent",
+    },
+)
+
+with urllib.request.urlopen(req) as resp:
+    result = json.loads(resp.read())
+    print(f"PR #{result['number']} created: {result['html_url']}")
+    print(f"PR number: {result['number']}")

--- a/_review_body.md
+++ b/_review_body.md
@@ -1,0 +1,125 @@
+## Chef Bianco's Review — Issue #27: First-Class Environments
+
+*Buongiorno.* I've tasted every line. The pasta is *al dente*, but there are a few burnt edges that need trimming before this goes to the pass.
+
+---
+
+### ✅ What's Done Well
+
+1. **Clean separation of concerns** — `DatabaseConfigManager` in `config.py` vs `load_project_config` in `utils.py` is the right split. The manager handles raw TOML/env resolution; the utility handles project-level config merging. Good.
+
+2. **Legacy compatibility** — `[connection]` still works when no `--env` is passed. The tests prove it. This is *critical* for a smooth migration. *Bravissimo.*
+
+3. **Error messages with available environments** — When a user types `--env=staging` and only `dev,prod` exist, they get told what's available. This is the kind of hospitality I expect in my kitchen.
+
+4. **CLI vars override env vars** — `test_environment_variables_cli_wins` proves the precedence chain is correct. CLI > env-level > defaults. Correct.
+
+5. **15 tests, all green** — Coverage on the new code is excellent. The fixture-based approach with `tempfile.TemporaryDirectory` is clean and hermetic.
+
+---
+
+### 🚩 Issues to Fix
+
+#### 1. `t4t/cli/main.py:108-133` — `--env` CLI option is NOT wired to any command
+
+The `CommandContext` class accepts `env`, and `load_project_config` accepts `env_name`, but **none of the CLI commands expose `--env` to the user**. The `run`, `build`, `test`, `debug`, `seed`, `compile`, `docs`, and `generate-lookups` commands all create `CommandContext(...)` without passing `env`.
+
+This means the entire feature is *inaccessible from the CLI*. A user cannot do `t4t run . --env=prod` — the option simply doesn't exist.
+
+**Fix:** Add `--env` as a `typer.Option` to every command that creates a `CommandContext`, and pass it through. Example for `run`:
+
+```python
+def cmd_run(
+    project_folder: str,
+    vars: str | None = None,
+    verbose: bool = False,
+    select: list[str] | None = None,
+    exclude: list[str] | None = None,
+    retry: bool = False,
+    auto_resolve_level_conflicts: bool = True,
+    env: str | None = None,  # <-- ADD THIS
+) -> None:
+    ctx = CommandContext(
+        project_folder=project_folder,
+        vars=vars,
+        verbose=verbose,
+        select=select,
+        exclude=exclude,
+        env=env,  # <-- PASS IT
+    )
+```
+
+And in `main.py`, add the option definition and pass it through each command call.
+
+#### 2. `t4t/engine/config.py:84-114` — `_load_toml_config` returns early when `env_name` is set, skipping legacy fallback
+
+When `env_name` is provided, the method returns immediately after loading the environment section (line 114). This means:
+- It **never checks** `[tool.t4t.database]`, `[tool.t4t.databases]`, or legacy `[connection]` as fallbacks.
+- If an environment section has an incomplete connection (e.g., missing `type`), the error message will be "No database configuration found" rather than something more helpful like "Environment 'dev' connection is missing required field 'type'".
+
+**Fix:** Either validate the environment connection fields before returning, or merge the environment connection on top of a base config loaded from legacy sections. The current design assumes environments are fully self-contained, which is fine — but then the validation should be more explicit.
+
+#### 3. `t4t/engine/config.py:108-109` — `_env_variables` key is stored but never used
+
+The `_env_variables` key is written to the config dict (line 109) but is never read by `_create_adapter_config` or any downstream consumer. The `AdapterConfig` dataclass has no `variables` field. This is dead data.
+
+**Fix:** Either:
+- Remove `_env_variables` entirely (it's handled by `load_project_config` in `utils.py`), or
+- Add a `variables` field to `AdapterConfig` and populate it.
+
+#### 4. `t4t/engine/config.py:112` — `_protected` key is stored but never used
+
+Same issue as `_env_variables`. The `protected` flag from `[environments.prod]` is stored in the config dict but never checked anywhere. No command refuses to run against a protected environment.
+
+**Fix:** Either implement the protection (e.g., require `--force` to run against a protected env) or remove it for now. Half-implemented safety features are worse than none — they give a false sense of security.
+
+#### 5. `t4t/cli/utils.py:70-98` — `load_project_config` duplicates environment resolution logic from `DatabaseConfigManager`
+
+The environment lookup logic (checking `environments` dict, building error messages, extracting connection/variables) is duplicated almost verbatim between `config.py:84-114` and `utils.py:70-98`. This is a maintenance risk — if the TOML structure changes, both must be updated.
+
+**Fix:** Extract the common logic into a shared helper, e.g.:
+
+```python
+def _resolve_environment(
+    data: dict, env_name: str
+) -> tuple[dict, dict, bool]:
+    ...
+```
+
+Then call it from both `DatabaseConfigManager._load_toml_config` and `load_project_config`.
+
+#### 6. `t4t/cli/context.py:44` — `self.env` is stored but never used after construction
+
+The `env` parameter is stored as `self.env` but is never referenced again in the class. It's only used to pass to `load_project_config`. Either remove it or document it as a future-use field.
+
+#### 7. `tests/test_environments.py:21` — Fixture uses `default_environment` key that is never read by the code
+
+The fixture `project_toml_with_environments` includes `default_environment = "dev"` (line 21), but **no code reads this key**. If the intent is to support a `default_environment` setting that auto-selects when no `--env` is given, it's not implemented.
+
+**Fix:** Either implement `default_environment` support in `load_project_config` and `DatabaseConfigManager`, or remove it from the fixture to avoid confusion.
+
+---
+
+### 📋 Summary
+
+| # | Severity | File | Issue |
+|---|----------|------|-------|
+| 1 | 🔴 **HIGH** | `t4t/cli/main.py` | `--env` option not wired to any CLI command — feature is inaccessible |
+| 2 | 🟡 **MEDIUM** | `t4t/engine/config.py:84-114` | Early return skips legacy fallback; weak validation on env connections |
+| 3 | 🟢 **LOW** | `t4t/engine/config.py:109` | `_env_variables` stored but never consumed |
+| 4 | 🟢 **LOW** | `t4t/engine/config.py:112` | `_protected` stored but never enforced |
+| 5 | 🟡 **MEDIUM** | `t4t/cli/utils.py:70-98` | Duplicated environment resolution logic |
+| 6 | 🟢 **LOW** | `t4t/cli/context.py:44` | `self.env` stored but unused after construction |
+| 7 | 🟢 **LOW** | `tests/test_environments.py:21` | `default_environment` in fixture but never implemented |
+
+---
+
+### Verdict
+
+The **design is correct** — the `[environments.*]` TOML structure, the precedence chain, and the legacy compatibility are all well thought out. The tests are thorough and pass.
+
+However, **issue #1 is a blocker**: the feature cannot be used from the CLI. Fix that, address the duplication (issue #5), and decide what to do with the half-implemented `protected` flag (issue #4), and this will be ready to merge.
+
+*La cucina è semplice, ma non è facile.* — The kitchen is simple, but it's not easy.
+
+— Chef Bianco

--- a/_review_pr.py
+++ b/_review_pr.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Leave a review comment on PR #68."""
+
+import json
+import urllib.request
+
+with open("/opt/data/.github_token") as f:
+    token = f.read().strip()
+
+with open("/opt/data/tee-for-transform/_review_body.md") as f:
+    body = f.read()
+
+data = json.dumps(
+    {
+        "event": "COMMENT",
+        "body": body,
+    }
+).encode()
+
+req = urllib.request.Request(
+    "https://api.github.com/repos/francescomucio/tee-for-transform/pulls/68/reviews",
+    data=data,
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "hermes-agent",
+    },
+)
+
+with urllib.request.urlopen(req) as resp:
+    result = json.loads(resp.read())
+    print(f"Review submitted: id={result.get('id')}")
+    print(f"State: {result.get('state')}")

--- a/examples/t_project/output/dependency_graph.json
+++ b/examples/t_project/output/dependency_graph.json
@@ -1,26 +1,26 @@
 {
   "nodes": [
-    "my_schema.my_view",
-    "my_schema.my_first_table_from_loop",
-    "test:my_schema.my_first_table.id.unique",
-    "test:my_schema.my_first_table.id.not_null",
-    "test:my_schema.my_first_table.name.not_null",
-    "my_schema.my_second_table_from_loop",
-    "my_schema.my_third_table_from_loop",
-    "my_schema.complex_join",
     "my_schema.my_second_table",
-    "my_schema.calculate_percentage",
-    "my_schema.recent_users",
-    "my_schema.users_summary",
-    "my_schema.incremental_example",
-    "test:my_schema.my_second_table.row_count_gt_0",
     "my_schema.my_first_table",
-    "test:my_schema.my_second_table.unique",
     "my_schema.my_third_table",
+    "test:my_schema.my_second_table.row_count_gt_0",
+    "my_schema.my_view",
+    "my_schema.recent_users",
     "my_schema.my_forth_table",
+    "my_schema.calculate_percentage",
+    "my_schema.users_summary",
     "test:my_schema.my_first_table.test_my_first_table",
+    "my_schema.my_first_table_from_loop",
+    "my_schema.my_second_table_from_loop",
+    "my_schema.incremental_example",
     "test:my_schema.my_first_table.row_count_gt_0",
-    "test:my_schema.my_second_table.name.not_null"
+    "test:my_schema.my_second_table.unique",
+    "test:my_schema.my_first_table.id.unique",
+    "my_schema.complex_join",
+    "test:my_schema.my_first_table.id.not_null",
+    "my_schema.my_third_table_from_loop",
+    "test:my_schema.my_second_table.name.not_null",
+    "test:my_schema.my_first_table.name.not_null"
   ],
   "edges": [
     [
@@ -217,14 +217,6 @@
     ]
   },
   "dependents": {
-    "my_schema.my_view": [],
-    "my_schema.my_first_table_from_loop": [],
-    "test:my_schema.my_first_table.id.unique": [],
-    "test:my_schema.my_first_table.id.not_null": [],
-    "test:my_schema.my_first_table.name.not_null": [],
-    "my_schema.my_second_table_from_loop": [],
-    "my_schema.my_third_table_from_loop": [],
-    "my_schema.complex_join": [],
     "my_schema.my_second_table": [
       "my_schema.my_second_table_from_loop",
       "my_schema.my_third_table",
@@ -232,11 +224,6 @@
       "test:my_schema.my_second_table.row_count_gt_0",
       "test:my_schema.my_second_table.unique"
     ],
-    "my_schema.calculate_percentage": [],
-    "my_schema.recent_users": [],
-    "my_schema.users_summary": [],
-    "my_schema.incremental_example": [],
-    "test:my_schema.my_second_table.row_count_gt_0": [],
     "my_schema.my_first_table": [
       "my_schema.users_summary",
       "my_schema.recent_users",
@@ -252,16 +239,29 @@
       "test:my_schema.my_first_table.row_count_gt_0",
       "test:my_schema.my_first_table.test_my_first_table"
     ],
-    "test:my_schema.my_second_table.unique": [],
     "my_schema.my_third_table": [
       "my_schema.my_third_table_from_loop"
     ],
+    "test:my_schema.my_second_table.row_count_gt_0": [],
+    "my_schema.my_view": [],
+    "my_schema.recent_users": [],
     "my_schema.my_forth_table": [
       "my_schema.my_view"
     ],
+    "my_schema.calculate_percentage": [],
+    "my_schema.users_summary": [],
     "test:my_schema.my_first_table.test_my_first_table": [],
+    "my_schema.my_first_table_from_loop": [],
+    "my_schema.my_second_table_from_loop": [],
+    "my_schema.incremental_example": [],
     "test:my_schema.my_first_table.row_count_gt_0": [],
-    "test:my_schema.my_second_table.name.not_null": []
+    "test:my_schema.my_second_table.unique": [],
+    "test:my_schema.my_first_table.id.unique": [],
+    "my_schema.complex_join": [],
+    "test:my_schema.my_first_table.id.not_null": [],
+    "my_schema.my_third_table_from_loop": [],
+    "test:my_schema.my_second_table.name.not_null": [],
+    "test:my_schema.my_first_table.name.not_null": []
   },
   "execution_order": [
     "my_schema.calculate_percentage",

--- a/examples/t_project/output/ots_modules/t_project__my_schema.ots.json
+++ b/examples/t_project/output/ots_modules/t_project__my_schema.ots.json
@@ -29,7 +29,7 @@
         "type": "table"
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/advanced_models.py"
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/advanced_models.py"
       }
     },
     {
@@ -53,7 +53,7 @@
         "type": "table"
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/advanced_models.py"
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/advanced_models.py"
       }
     },
     {
@@ -77,7 +77,7 @@
         "type": "table"
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/advanced_models.py"
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/advanced_models.py"
       }
     },
     {
@@ -101,7 +101,7 @@
         "type": "table"
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/advanced_models.py"
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/advanced_models.py"
       }
     },
     {
@@ -125,7 +125,7 @@
         "type": "table"
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/advanced_models.py"
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/advanced_models.py"
       }
     },
     {
@@ -149,7 +149,7 @@
         "type": "table"
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/advanced_models.py"
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/advanced_models.py"
       }
     },
     {
@@ -196,7 +196,7 @@
         }
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/incremental_example.py"
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/incremental_example.py"
       }
     },
     {
@@ -234,7 +234,7 @@
         "type": "table"
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/my_first_table.py"
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/my_first_table.py"
       },
       "tests": {
         "columns": {
@@ -287,7 +287,7 @@
         "type": "view"
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/my_second_table.py"
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/my_second_table.py"
       },
       "tests": {
         "columns": {
@@ -322,7 +322,7 @@
         "type": "view"
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/my_view.py"
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/my_view.py"
       }
     },
     {
@@ -346,7 +346,7 @@
         "type": "table"
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/my_forth_table.sql"
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/my_forth_table.sql"
       }
     },
     {
@@ -371,7 +371,7 @@
         "type": "table"
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/my_third_table.sql"
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/my_third_table.sql"
       }
     }
   ],
@@ -386,7 +386,7 @@
         "database_specific": {}
       },
       "metadata": {
-        "file_path": "/tmp/t4t-fixes/examples/t_project/functions/my_schema/calculate_percentage.py",
+        "file_path": "/opt/data/tee-for-transform/examples/t_project/functions/my_schema/calculate_percentage.py",
         "tags": [
           "math",
           "utility"

--- a/examples/t_project/output/ots_modules/t_project_test_library.ots.json
+++ b/examples/t_project/output/ots_modules/t_project_test_library.ots.json
@@ -17,18 +17,18 @@
       "sql": "SELECT id\n    FROM @table_name\n    WHERE id IS NULL",
       "parameters": []
     },
-    "example_custom_test": {
-      "type": "sql",
-      "level": "table",
-      "description": "Example custom SQL test This test checks that a table has at least 5 rows The table_name variable is automatically substituted",
-      "sql": "SELECT 1 as violation\nFROM @table_name\nGROUP BY 1\nHAVING COUNT(*) < 5",
-      "parameters": []
-    },
     "column_not_negative": {
       "type": "sql",
       "level": "column",
       "description": "Column-level SQL test example Checks that a numeric column has no negative values Can be used on any column by referencing @column_name",
       "sql": "SELECT @column_name\nFROM @table_name\nWHERE @column_name < 0",
+      "parameters": []
+    },
+    "example_custom_test": {
+      "type": "sql",
+      "level": "table",
+      "description": "Example custom SQL test This test checks that a table has at least 5 rows The table_name variable is automatically substituted",
+      "sql": "SELECT 1 as violation\nFROM @table_name\nGROUP BY 1\nHAVING COUNT(*) < 5",
       "parameters": []
     },
     "check_minimum_rows": {

--- a/examples/t_project/output/parsed_models.json
+++ b/examples/t_project/output/parsed_models.json
@@ -17,7 +17,7 @@
       "description": "Summary of user data",
       "variables": [],
       "metadata": {},
-      "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/advanced_models.py"
+      "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/advanced_models.py"
     },
     "sqlglot_hash": "4bbc220872f45df14551e0a9d8dd12c0bfacd0fc9887fe362ce12f6362fa2b07",
     "needs_evaluation": false
@@ -40,7 +40,7 @@
       "description": null,
       "variables": [],
       "metadata": {},
-      "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/advanced_models.py"
+      "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/advanced_models.py"
     },
     "sqlglot_hash": "4bbc220872f45df14551e0a9d8dd12c0bfacd0fc9887fe362ce12f6362fa2b07",
     "needs_evaluation": false
@@ -63,7 +63,7 @@
       "description": null,
       "variables": [],
       "metadata": {},
-      "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/advanced_models.py"
+      "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/advanced_models.py"
     },
     "sqlglot_hash": "4bbc220872f45df14551e0a9d8dd12c0bfacd0fc9887fe362ce12f6362fa2b07",
     "needs_evaluation": false
@@ -86,7 +86,7 @@
       "description": "Select from  my_schema.my_first_table",
       "variables": [],
       "metadata": {},
-      "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/advanced_models.py"
+      "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/advanced_models.py"
     },
     "sqlglot_hash": "4bbc220872f45df14551e0a9d8dd12c0bfacd0fc9887fe362ce12f6362fa2b07"
   },
@@ -108,7 +108,7 @@
       "description": "Select from  my_schema.my_second_table",
       "variables": [],
       "metadata": {},
-      "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/advanced_models.py"
+      "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/advanced_models.py"
     },
     "sqlglot_hash": "c631a5897c7d8164facaf39df4d434cc4bfdc5a743249b3601b695f4e7381382"
   },
@@ -130,7 +130,7 @@
       "description": "Select from  my_schema.my_third_table",
       "variables": [],
       "metadata": {},
-      "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/advanced_models.py"
+      "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/advanced_models.py"
     },
     "sqlglot_hash": "5d113606605b0563befa9443f3842146977ac11761f528123e20f9e7be151172"
   },
@@ -165,7 +165,7 @@
           }
         }
       },
-      "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/incremental_example.py"
+      "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/incremental_example.py"
     },
     "sqlglot_hash": "9f97e2965f504ca16944fd759f428c715575cf30926165fef90dac6496c16e56"
   },
@@ -213,7 +213,7 @@
           "test_my_first_table"
         ]
       },
-      "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/my_first_table.py"
+      "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/my_first_table.py"
     },
     "sqlglot_hash": "cf5d755536438a4884a5d23ecd12700d0565d907f945ae4a48709a3258e1ea15"
   },
@@ -256,7 +256,7 @@
           "unique"
         ]
       },
-      "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/my_second_table.py"
+      "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/my_second_table.py"
     },
     "sqlglot_hash": "7bda040e8397f8974e0d3bcc4c85093fd1ec961835cdcfcffb66196fc49d177b"
   },
@@ -280,7 +280,7 @@
       "metadata": {
         "materialization": "view"
       },
-      "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/my_view.py"
+      "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/my_view.py"
     },
     "sqlglot_hash": "5411f7ecf1931833c59ce4d1a8ca68cba40be26929d6e7c21f52c4a8c81af511"
   },
@@ -302,7 +302,7 @@
       "description": "SQL model for my_schema.my_forth_table",
       "variables": [],
       "metadata": {},
-      "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/my_forth_table.sql"
+      "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/my_forth_table.sql"
     },
     "sqlglot_hash": "3b1ecd8d945c471109194ea08d8bba1f485fcdb8e739a6fc97f49c063e92f90d"
   },
@@ -325,7 +325,7 @@
       "description": "SQL model for my_schema.my_third_table",
       "variables": [],
       "metadata": {},
-      "file_path": "/tmp/t4t-fixes/examples/t_project/models/my_schema/my_third_table.sql"
+      "file_path": "/opt/data/tee-for-transform/examples/t_project/models/my_schema/my_third_table.sql"
     },
     "sqlglot_hash": "a06a906e28d9ae187d4f47471a7862f6c743cb784380996e41422a2720a953d9"
   }

--- a/t4t/cli/commands/build.py
+++ b/t4t/cli/commands/build.py
@@ -39,6 +39,7 @@ def cmd_build(
     exclude: list[str] | None = None,
     retry: bool = False,
     auto_resolve_level_conflicts: bool = True,
+    env: str | None = None,
 ) -> None:
     """Execute the build command."""
     ctx = CommandContext(
@@ -47,7 +48,9 @@ def cmd_build(
         verbose=verbose,
         select=select,
         exclude=exclude,
+        env=env,
     )
+    ctx.echo_environment()
     connection_manager = None
 
     try:
@@ -104,6 +107,7 @@ def cmd_build(
             select_patterns=select_patterns,
             exclude_patterns=ctx.exclude_patterns,
             project_config=ctx.config,
+            environment=ctx.env,
         )
 
         # Calculate statistics

--- a/t4t/cli/commands/compile.py
+++ b/t4t/cli/commands/compile.py
@@ -18,6 +18,7 @@ def cmd_compile(
     vars: str | None = None,
     verbose: bool = False,
     format: OutputFormat = "json",
+    env: str | None = None,
 ) -> None:
     """
     Compile t4t project to OTS modules.
@@ -35,12 +36,15 @@ def cmd_compile(
         vars: Optional variables for SQL substitution (JSON format)
         verbose: Enable verbose output
         format: Output format ("json" or "yaml")
+        env: Optional environment name to use
     """
     ctx = CommandContext(
         project_folder=project_folder,
         vars=vars,
         verbose=verbose,
+        env=env,
     )
+    ctx.echo_environment()
 
     try:
         typer.echo(f"Compiling project: {project_folder}")

--- a/t4t/cli/commands/debug.py
+++ b/t4t/cli/commands/debug.py
@@ -14,13 +14,16 @@ def cmd_debug(
     project_folder: str,
     vars: str | None = None,
     verbose: bool = False,
+    env: str | None = None,
 ) -> None:
     """Execute the debug command to test database connectivity."""
     ctx = CommandContext(
         project_folder=project_folder,
         vars=vars,
         verbose=verbose,
+        env=env,
     )
+    ctx.echo_environment()
     connection_manager = None
 
     try:

--- a/t4t/cli/commands/docs.py
+++ b/t4t/cli/commands/docs.py
@@ -114,6 +114,7 @@ def cmd_docs(
     auto_resolve_level_conflicts: bool = True,
     skip_lookups: bool = False,
     infer_dim_from_column_names: bool = False,
+    env: str | None = None,
 ) -> None:
     """
     Generate static documentation site with dependency graph.
@@ -133,7 +134,9 @@ def cmd_docs(
         project_folder=project_folder,
         vars=vars,
         verbose=verbose,
+        env=env,
     )
+    ctx.echo_environment()
 
     try:
         typer.echo(f"Generating documentation for project: {project_folder}")

--- a/t4t/cli/commands/generate_lookups.py
+++ b/t4t/cli/commands/generate_lookups.py
@@ -13,6 +13,7 @@ def cmd_generate_lookups(
     vars: str | None = None,
     verbose: bool = False,
     auto_resolve_level_conflicts: bool = False,
+    env: str | None = None,
 ) -> None:
     """
     Generate lookup tables from hierarchical dimensions.
@@ -23,7 +24,9 @@ def cmd_generate_lookups(
         project_folder=project_folder,
         vars=vars,
         verbose=verbose,
+        env=env,
     )
+    ctx.echo_environment()
 
     try:
         typer.echo(f"Generating lookups for project: {ctx.project_path}")

--- a/t4t/cli/commands/ots.py
+++ b/t4t/cli/commands/ots.py
@@ -18,6 +18,7 @@ def cmd_ots_run(
     verbose: bool = False,
     select: list[str] | None = None,
     exclude: list[str] | None = None,
+    env: str | None = None,
 ) -> None:
     """
     Execute OTS modules.
@@ -29,6 +30,7 @@ def cmd_ots_run(
         verbose: Enable verbose output
         select: Select models (can be used multiple times)
         exclude: Exclude models (can be used multiple times)
+        env: Optional environment name to use
     """
     ots_path_obj = Path(ots_path)
 
@@ -67,7 +69,9 @@ def cmd_ots_run(
                 verbose=verbose,
                 select=select,
                 exclude=exclude,
+                env=env,
             )
+            ctx.echo_environment()
             connection_config = ctx.config["connection"]
             project_path = ctx.project_path
             variables = ctx.vars

--- a/t4t/cli/commands/run.py
+++ b/t4t/cli/commands/run.py
@@ -37,6 +37,7 @@ def cmd_run(
     exclude: list[str] | None = None,
     retry: bool = False,
     auto_resolve_level_conflicts: bool = True,
+    env: str | None = None,
 ) -> None:
     """Execute the run command."""
     ctx = CommandContext(
@@ -45,7 +46,9 @@ def cmd_run(
         verbose=verbose,
         select=select,
         exclude=exclude,
+        env=env,
     )
+    ctx.echo_environment()
     connection_manager = None
 
     try:
@@ -102,6 +105,7 @@ def cmd_run(
             select_patterns=select_patterns,
             exclude_patterns=ctx.exclude_patterns,
             project_config=ctx.config,
+            environment=ctx.env,
         )
 
         # Calculate statistics

--- a/t4t/cli/commands/seed.py
+++ b/t4t/cli/commands/seed.py
@@ -13,13 +13,16 @@ def cmd_seed(
     project_folder: str,
     vars: str | None = None,
     verbose: bool = False,
+    env: str | None = None,
 ) -> None:
     """Execute the seed command to load seed files into the database."""
     ctx = CommandContext(
         project_folder=project_folder,
         vars=vars,
         verbose=verbose,
+        env=env,
     )
+    ctx.echo_environment()
 
     try:
         typer.echo(f"Loading seeds from project: {project_folder}")

--- a/t4t/cli/commands/test.py
+++ b/t4t/cli/commands/test.py
@@ -20,6 +20,7 @@ def cmd_test(
     verbose: bool = False,
     select: list[str] | None = None,
     exclude: list[str] | None = None,
+    env: str | None = None,
 ) -> None:
     """Execute the test command."""
     ctx = CommandContext(
@@ -28,7 +29,9 @@ def cmd_test(
         verbose=verbose,
         select=select,
         exclude=exclude,
+        env=env,
     )
+    ctx.echo_environment()
 
     try:
         typer.echo(f"Running tests for project: {project_folder}")

--- a/t4t/cli/context.py
+++ b/t4t/cli/context.py
@@ -2,6 +2,7 @@
 Command context for shared setup across CLI commands.
 """
 
+import os
 from pathlib import Path
 
 import typer
@@ -15,6 +16,12 @@ class CommandContext:
 
     Handles common setup: parsing variables, loading config, setting up logging,
     and extracting selection criteria.
+
+    Environment resolution order (highest to lowest priority):
+      1. ``--env`` CLI flag (explicit)
+      2. ``T4T_ENV`` environment variable
+      3. ``default_environment`` key in ``project.toml``
+      4. Legacy ``[connection]`` section (no named environment)
     """
 
     def __init__(
@@ -24,6 +31,7 @@ class CommandContext:
         verbose: bool = False,
         select: list[str] | None = None,
         exclude: list[str] | None = None,
+        env: str | None = None,
     ) -> None:
         """
         Initialize command context from parameters.
@@ -34,12 +42,24 @@ class CommandContext:
             verbose: Enable verbose output
             select: Selection patterns
             exclude: Exclusion patterns
+            env: Optional environment name to use
         """
         # Parse variables if provided
         self.vars = parse_vars(vars)
 
-        # Load project configuration
-        self.config = load_project_config(project_folder, self.vars)
+        # Resolve environment: --env flag > T4T_ENV env var > default_environment > legacy
+        self.env = env
+        if self.env is None:
+            self.env = os.environ.get("T4T_ENV")
+
+        # Load project configuration (pass env so load_project_config can resolve it)
+        self.config = load_project_config(project_folder, self.vars, self.env)
+
+        # If still no env, check for default_environment in config
+        if self.env is None and "default_environment" in self.config:
+            self.env = self.config["default_environment"]
+            # Reload config with the default environment
+            self.config = load_project_config(project_folder, self.vars, self.env)
 
         # Set up logging
         self.verbose = verbose
@@ -51,6 +71,13 @@ class CommandContext:
         # Extract selection criteria
         self.select_patterns = select
         self.exclude_patterns = exclude
+
+    def echo_environment(self) -> None:
+        """Print the active environment name."""
+        if self.env:
+            typer.echo(f"Environment: {self.env}")
+        else:
+            typer.echo("Environment: default (legacy [connection])")
 
     def handle_error(self, error: Exception, show_traceback: bool = None) -> None:
         """

--- a/t4t/cli/main.py
+++ b/t4t/cli/main.py
@@ -291,6 +291,7 @@ def docs(
         "--infer-dim-from-column-names",
         help="Infer dimensional links from fact column names matching dimension/lookup primary keys.",
     ),
+    env: str | None = typer.Option(None, "--env", help="Environment name to use"),
 ) -> None:
     """Generate static documentation site with dependency graph."""
     _check_required_argument(ctx, "project_folder", project_folder)
@@ -302,6 +303,7 @@ def docs(
         auto_resolve_level_conflicts=auto_resolve_level_conflicts,
         skip_lookups=skip_lookups,
         infer_dim_from_column_names=infer_dim_from_column_names,
+        env=env,
     )
 
 
@@ -316,6 +318,7 @@ def generate_lookups(
         "--auto-resolve-level-conflicts",
         help="Automatically resolve duplicate hierarchy level names as <dimension>_<level>.",
     ),
+    env: str | None = typer.Option(None, "--env", help="Environment name to use"),
 ) -> None:
     """Generate lookup tables from hierarchical dimensions."""
     _check_required_argument(ctx, "project_folder", project_folder)
@@ -324,6 +327,7 @@ def generate_lookups(
         vars=vars,
         verbose=verbose,
         auto_resolve_level_conflicts=auto_resolve_level_conflicts,
+        env=env,
     )
 
 
@@ -426,6 +430,7 @@ def ots_run(
     verbose: bool = VERBOSE_OPTION,
     select: list[str] | None = SELECT_OPTION,
     exclude: list[str] | None = EXCLUDE_OPTION,
+    env: str | None = typer.Option(None, "--env", help="Environment name to use"),
 ) -> None:
     """Execute OTS modules."""
     _check_required_argument(ctx, "ots_path", ots_path)
@@ -436,6 +441,7 @@ def ots_run(
         verbose=verbose,
         select=select,
         exclude=exclude,
+        env=env,
     )
 
 

--- a/t4t/cli/main.py
+++ b/t4t/cli/main.py
@@ -119,6 +119,7 @@ def run(
         "--auto-resolve-level-conflicts",
         help="Automatically resolve duplicate hierarchy level names as <dimension>_<level> during lookup generation.",
     ),
+    env: str | None = typer.Option(None, "--env", help="Environment name to use"),
 ) -> None:
     """Parse and execute SQL models."""
     _check_required_argument(ctx, "project_folder", project_folder)
@@ -130,6 +131,7 @@ def run(
         exclude=exclude,
         retry=retry,
         auto_resolve_level_conflicts=auto_resolve_level_conflicts,
+        env=env,
     )
 
 
@@ -139,6 +141,7 @@ def debug(
     project_folder: str | None = PROJECT_FOLDER_ARG,
     verbose: bool = VERBOSE_OPTION,
     vars: str | None = VARS_OPTION,
+    env: str | None = typer.Option(None, "--env", help="Environment name to use"),
 ) -> None:
     """Test database connectivity and configuration."""
     _check_required_argument(ctx, "project_folder", project_folder)
@@ -146,6 +149,7 @@ def debug(
         project_folder=project_folder,
         vars=vars,
         verbose=verbose,
+        env=env,
     )
 
 
@@ -157,6 +161,7 @@ def test(
     vars: str | None = VARS_OPTION,
     select: list[str] | None = SELECT_OPTION,
     exclude: list[str] | None = EXCLUDE_OPTION,
+    env: str | None = typer.Option(None, "--env", help="Environment name to use"),
 ) -> None:
     """Run data quality tests on models."""
     _check_required_argument(ctx, "project_folder", project_folder)
@@ -166,6 +171,7 @@ def test(
         verbose=verbose,
         select=select,
         exclude=exclude,
+        env=env,
     )
 
 
@@ -183,6 +189,7 @@ def build(
         "--auto-resolve-level-conflicts",
         help="Automatically resolve duplicate hierarchy level names as <dimension>_<level> during lookup generation.",
     ),
+    env: str | None = typer.Option(None, "--env", help="Environment name to use"),
 ) -> None:
     """Build models with tests (stops on test failure)."""
     _check_required_argument(ctx, "project_folder", project_folder)
@@ -194,6 +201,7 @@ def build(
         exclude=exclude,
         retry=retry,
         auto_resolve_level_conflicts=auto_resolve_level_conflicts,
+        env=env,
     )
 
 
@@ -203,6 +211,7 @@ def seed(
     project_folder: str | None = PROJECT_FOLDER_ARG,
     verbose: bool = VERBOSE_OPTION,
     vars: str | None = VARS_OPTION,
+    env: str | None = typer.Option(None, "--env", help="Environment name to use"),
 ) -> None:
     """Load seed files (CSV, JSON, TSV) into database tables."""
     _check_required_argument(ctx, "project_folder", project_folder)
@@ -210,6 +219,7 @@ def seed(
         project_folder=project_folder,
         vars=vars,
         verbose=verbose,
+        env=env,
     )
 
 
@@ -244,6 +254,7 @@ def compile(
     format: OutputFormat = typer.Option(
         "json", "-f", "--format", help="Output format: json or yaml", callback=validate_format
     ),
+    env: str | None = typer.Option(None, "--env", help="Environment name to use"),
 ) -> None:
     """Compile t4t project to OTS modules."""
     _check_required_argument(ctx, "project_folder", project_folder)
@@ -252,6 +263,7 @@ def compile(
         vars=vars,
         verbose=verbose,
         format=format,
+        env=env,
     )
 
 

--- a/t4t/cli/utils.py
+++ b/t4t/cli/utils.py
@@ -76,6 +76,15 @@ def load_project_config(
                 f"Environment '{env}' in project.toml must contain a 'connection' section"
             )
         config["connection"] = env_config["connection"]
+        # Merge env-level variables into config
+        if "variables" in env_config:
+            env_vars = env_config["variables"]
+            if isinstance(env_vars, dict):
+                existing_vars = config.get("vars", {})
+                if isinstance(existing_vars, dict):
+                    config["vars"] = {**existing_vars, **env_vars}
+                else:
+                    config["vars"] = env_vars
     elif "connection" not in config:
         raise ValueError("project.toml must contain 'connection' configuration")
 

--- a/t4t/cli/utils.py
+++ b/t4t/cli/utils.py
@@ -33,7 +33,7 @@ def parse_vars(vars_string: str | None) -> dict[str, Any]:
 
 
 def load_project_config(
-    project_folder: str, vars_dict: dict[str, Any] | None = None
+    project_folder: str, vars_dict: dict[str, Any] | None = None, env: str | None = None
 ) -> dict[str, Any]:
     """
     Load project configuration from project.toml file and merge with variables.
@@ -41,6 +41,7 @@ def load_project_config(
     Args:
         project_folder: Path to the project folder
         vars_dict: Optional dictionary of variables to merge into config
+        env: Optional environment name to use for connection resolution
 
     Returns:
         Dictionary containing project configuration with variables merged
@@ -60,7 +61,22 @@ def load_project_config(
     if "project_folder" not in config:
         raise ValueError("project.toml must contain 'project_folder' setting")
 
-    if "connection" not in config:
+    # Resolve connection config based on environment
+    if env:
+        # Use named environment from [environments.<env>]
+        environments = config.get("environments", {})
+        if env not in environments:
+            raise ValueError(
+                f"Environment '{env}' not found in project.toml. "
+                f"Available environments: {', '.join(environments.keys())}"
+            )
+        env_config = environments[env]
+        if "connection" not in env_config:
+            raise ValueError(
+                f"Environment '{env}' in project.toml must contain a 'connection' section"
+            )
+        config["connection"] = env_config["connection"]
+    elif "connection" not in config:
         raise ValueError("project.toml must contain 'connection' configuration")
 
     # Merge variables into config

--- a/t4t/executor.py
+++ b/t4t/executor.py
@@ -31,6 +31,7 @@ def _try_persist_run_manifest(
     variables: dict[str, Any] | None = None,
     function_names: set[str] | None = None,
     cli_args: dict[str, Any] | None = None,
+    environment: str | None = None,
 ) -> None:
     """Write last_run.json and append to runs.sqlite; failures are logged only."""
     logger = logging.getLogger(__name__)
@@ -48,6 +49,7 @@ def _try_persist_run_manifest(
             variables=variables,
             cli_args=cli_args,
             function_names=function_names,
+            environment=environment,
         )
         backend = LocalStateBackend(Path(project_folder) / "output")
         backend.append_run(manifest)
@@ -63,6 +65,7 @@ def execute_models(
     select_patterns: list[str] | None = None,
     exclude_patterns: list[str] | None = None,
     project_config: dict[str, Any] | None = None,
+    environment: str | None = None,
 ) -> dict[str, Any]:
     """
     Execute SQL models by compiling to OTS modules and running them in dependency order.
@@ -133,6 +136,7 @@ def execute_models(
             project_config=project_config,
             variables=variables,
             function_names=fnames or None,
+            environment=environment,
         )
         return empty
 
@@ -171,6 +175,7 @@ def execute_models(
                 project_config=project_config,
                 variables=variables,
                 function_names=fnames or None,
+                environment=environment,
             )
             return empty
 
@@ -251,6 +256,7 @@ def execute_models(
             project_config=project_config,
             variables=variables,
             function_names=fnames or None,
+            environment=environment,
         )
         return results
 
@@ -267,6 +273,7 @@ def build_models(
     select_patterns: list[str] | None = None,
     exclude_patterns: list[str] | None = None,
     project_config: dict[str, Any] | None = None,
+    environment: str | None = None,
 ) -> dict[str, Any]:
     """
     Build models with interleaved test execution, stopping on test failures.
@@ -376,6 +383,7 @@ def build_models(
             project_config=project_config,
             variables=variables,
             function_names=None,
+            environment=environment,
         )
         return empty_results
 
@@ -453,6 +461,7 @@ def build_models(
             project_config=project_config,
             variables=variables,
             function_names=fn_build or None,
+            environment=environment,
         )
         return results
 

--- a/t4t/state/manifest.py
+++ b/t4t/state/manifest.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Literal
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 NodeStatus = Literal["success", "failed", "skipped"]
 FuncStatus = Literal["success", "failed"]
@@ -65,6 +65,7 @@ class RunManifest:
     nodes: list[NodeResult]
     functions: list[FunctionResult]
     cli_args: dict[str, Any] | None = None
+    environment: str | None = None
 
 
 def manifest_to_dict(manifest: RunManifest) -> dict[str, Any]:
@@ -89,6 +90,7 @@ def manifest_from_dict(d: dict[str, Any]) -> RunManifest:
         nodes=nodes,
         functions=functions,
         cli_args=d.get("cli_args"),
+        environment=d.get("environment"),
     )
 
 
@@ -117,6 +119,7 @@ def results_to_manifest(
     variables: dict[str, Any] | None = None,
     cli_args: dict[str, Any] | None = None,
     function_names: set[str] | None = None,
+    environment: str | None = None,
 ) -> RunManifest:
     """Normalize execute_models or build_models result dicts into a RunManifest."""
     analysis = results.get("analysis") or {}
@@ -231,6 +234,7 @@ def results_to_manifest(
         nodes=nodes_out,
         functions=func_out,
         cli_args=cli_args,
+        environment=environment,
     )
 
 

--- a/tests/cli/commands/test_build.py
+++ b/tests/cli/commands/test_build.py
@@ -69,6 +69,7 @@ class TestBuildCommand:
         mock_ctx.select_patterns = None
         mock_ctx.exclude_patterns = None
         mock_ctx.config = mock_config
+        mock_ctx.env = None
         mock_ctx.print_variables_info = Mock()
         mock_ctx.print_selection_info = Mock()
         mock_context_class.return_value = mock_ctx
@@ -113,6 +114,7 @@ class TestBuildCommand:
             select_patterns=None,
             exclude_patterns=None,
             project_config=mock_ctx.config,
+            environment=None,
         )
 
     @patch("t4t.cli.commands.build.build_models")

--- a/tests/cli/commands/test_run.py
+++ b/tests/cli/commands/test_run.py
@@ -58,6 +58,7 @@ class TestRunCommand:
         mock_ctx.select_patterns = None
         mock_ctx.exclude_patterns = None
         mock_ctx.config = {"connection": {"type": "duckdb", "path": ":memory:"}}
+        mock_ctx.env = None
         mock_ctx.print_variables_info = Mock()
         mock_ctx.print_selection_info = Mock()
         mock_context_class.return_value = mock_ctx
@@ -90,6 +91,7 @@ class TestRunCommand:
             select_patterns=None,
             exclude_patterns=None,
             project_config=mock_ctx.config,
+            environment=None,
         )
 
     @patch("t4t.cli.commands.run.execute_models")


### PR DESCRIPTION
## Summary

Implements issue #28: `--env` flag on all commands.

### Changes

- **`t4t/cli/main.py`** — Added `--env` option to `run`, `build`, `test`, `seed`, `compile`, `debug`, `docs`, `generate-lookups`
- **`t4t/cli/context.py`** — `CommandContext` now resolves env via: `--env` flag → `T4T_ENV` env var → `default_environment` → legacy `[connection]`
- **`t4t/cli/utils.py`** — `load_project_config` accepts `env` parameter
- **`t4t/state/manifest.py`** — `RunManifest` now has `environment` field, `SCHEMA_VERSION` bumped to 2
- **`t4t/executor.py`** — `execute_models`/`build_models` pass `environment` to manifest
- **All `cmd_*` functions** — Accept `env` parameter, echo active environment at start

### Resolution order

1. `--env` CLI flag (highest)
2. `T4T_ENV` environment variable
3. `default_environment` in project.toml
4. Legacy `[connection]` section (no named environment)

### Testing

- 1373 tests passed, 4 failed (pre-existing), 30 errors (pre-existing Snowflake tests)
- Ruff linting: all checks passed