### PR TITLE
feat: secret references in connection config (env:/file:) — #29

### DIFF
--- a/t4t/engine/config.py
+++ b/t4t/engine/config.py
@@ -6,6 +6,7 @@ and environment variables with proper precedence and validation.
 
 import logging
 import os
+import re
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -13,25 +14,49 @@ from typing import Any
 from t4t.adapters.base import AdapterConfig
 
 # Keys that are considered secret-bearing and should be redacted in logs
-_SECRET_KEYS = frozenset({"password", "token", "secret"})
+_SECRET_KEYS = frozenset(
+    {
+        "password",
+        "token",
+        "secret",
+        "api_key",
+        "private_key",
+        "access_key",
+        "client_secret",
+    }
+)
 
 # Reference prefix scheme — extensible to future managers (vault:, aws-sm:, ...)
 _REF_PREFIXES = frozenset({"env:", "file:"})
 
+# Regex for a valid reference prefix word (letters, digits, hyphens, underscores)
+_REF_PREFIX_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]*$")
+
 
 def _looks_like_reference(value: str) -> bool:
-    """Check if a string value looks like a reference (prefix:rest).
+    """Check if a string value looks like a known reference (prefix:rest).
 
-    A value looks like a reference if it matches the pattern ``word:``
-    at the start, where ``word`` contains only letters, digits, hyphens,
-    and underscores.  This catches unknown prefixes such as ``vault:``
-    or ``aws-sm:`` so we can raise a clear error instead of silently
-    treating them as literal values.
+    A value looks like a reference if its prefix is one of the known
+    prefixes in ``_REF_PREFIXES``.  This avoids false positives such as
+    ``localhost:5432`` or ``C:/path``.
     """
     if ":" not in value:
         return False
     prefix, _, _ = value.partition(":")
-    return bool(prefix) and prefix.isidentifier()
+    return f"{prefix}:" in _REF_PREFIXES
+
+
+def _looks_like_any_reference(value: str) -> bool:
+    """Check if a string matches the general ``word:rest`` reference pattern.
+
+    Unlike ``_looks_like_reference``, this does not require the prefix to
+    be known — it catches unknown prefixes such as ``vault:`` or ``aws-sm:``
+    so we can raise a clear error.
+    """
+    if ":" not in value:
+        return False
+    prefix, _, _ = value.partition(":")
+    return bool(prefix) and bool(_REF_PREFIX_RE.match(prefix))
 
 
 class DatabaseConfigManager:
@@ -92,21 +117,18 @@ class DatabaseConfigManager:
             # Check for single database config in tool.t4t.database
             if "database" in t4t_config:
                 config.update(t4t_config["database"])
-                self._warn_literal_secrets(config)
                 return config
 
             # Check for multiple database configs in tool.t4t.databases
             databases = t4t_config.get("databases", {})
             if isinstance(databases, dict) and config_name in databases:
                 config.update(databases[config_name])
-                self._warn_literal_secrets(config)
                 return config
 
             # Check for legacy [connection] section
             if "connection" in data:
                 self.logger.debug("Using legacy [connection] section")
                 config.update(data["connection"])
-                self._warn_literal_secrets(config)
                 return config
 
             self.logger.debug(f"No database configuration '{config_name}' found in TOML file")
@@ -155,6 +177,10 @@ class DatabaseConfigManager:
         """Merge TOML and environment configurations."""
         merged = toml_config.copy()
         merged.update(env_config)
+        # Warn about literal secrets in the merged config (before resolution,
+        # so env: references are still detected as non-literal and env var
+        # overrides suppress warnings for overridden TOML values).
+        self._warn_literal_secrets(merged)
         # Resolve secret references after env var merge, so T4T_DB_* overrides
         # still work and don't need the reference syntax themselves.
         merged = self._resolve_secret_refs(merged)
@@ -196,8 +222,12 @@ class DatabaseConfigManager:
                 file_path = value[len("file:") :]
                 if not file_path:
                     raise ValueError(f"Empty file: reference for key '{key}'")
+                # Resolve relative paths against project_root
+                p = Path(file_path)
+                if not p.is_absolute():
+                    p = self.project_root / p
                 try:
-                    file_val = Path(file_path).read_text(encoding="utf-8").rstrip("\n")
+                    file_val = p.read_text(encoding="utf-8").rstrip("\n")
                 except FileNotFoundError:
                     raise ValueError(
                         f"Secret file '{file_path}' referenced in config key '{key}' not found"
@@ -214,7 +244,7 @@ class DatabaseConfigManager:
                     ) from None
                 resolved[key] = file_val
 
-            elif _looks_like_reference(value):
+            elif _looks_like_any_reference(value):
                 # Value looks like a reference (e.g. "vault:my-secret") but
                 # uses an unsupported prefix.
                 prefix = value.split(":", 1)[0] + ":"

--- a/t4t/engine/config.py
+++ b/t4t/engine/config.py
@@ -1,5 +1,4 @@
-"""
-Database configuration management.
+"""Database configuration management.
 
 This module handles loading database configurations from pyproject.toml
 and environment variables with proper precedence and validation.
@@ -12,6 +11,27 @@ from pathlib import Path
 from typing import Any
 
 from t4t.adapters.base import AdapterConfig
+
+# Keys that are considered secret-bearing and should be redacted in logs
+_SECRET_KEYS = frozenset({"password", "token", "secret"})
+
+# Reference prefix scheme — extensible to future managers (vault:, aws-sm:, ...)
+_REF_PREFIXES = frozenset({"env:", "file:"})
+
+
+def _looks_like_reference(value: str) -> bool:
+    """Check if a string value looks like a reference (prefix:rest).
+
+    A value looks like a reference if it matches the pattern ``word:``
+    at the start, where ``word`` contains only letters, digits, hyphens,
+    and underscores.  This catches unknown prefixes such as ``vault:``
+    or ``aws-sm:`` so we can raise a clear error instead of silently
+    treating them as literal values.
+    """
+    if ":" not in value:
+        return False
+    prefix, _, _ = value.partition(":")
+    return bool(prefix) and prefix.isidentifier()
 
 
 class DatabaseConfigManager:
@@ -72,18 +92,21 @@ class DatabaseConfigManager:
             # Check for single database config in tool.t4t.database
             if "database" in t4t_config:
                 config.update(t4t_config["database"])
+                self._warn_literal_secrets(config)
                 return config
 
             # Check for multiple database configs in tool.t4t.databases
             databases = t4t_config.get("databases", {})
             if isinstance(databases, dict) and config_name in databases:
                 config.update(databases[config_name])
+                self._warn_literal_secrets(config)
                 return config
 
             # Check for legacy [connection] section
             if "connection" in data:
                 self.logger.debug("Using legacy [connection] section")
                 config.update(data["connection"])
+                self._warn_literal_secrets(config)
                 return config
 
             self.logger.debug(f"No database configuration '{config_name}' found in TOML file")
@@ -132,12 +155,109 @@ class DatabaseConfigManager:
         """Merge TOML and environment configurations."""
         merged = toml_config.copy()
         merged.update(env_config)
+        # Resolve secret references after env var merge, so T4T_DB_* overrides
+        # still work and don't need the reference syntax themselves.
+        merged = self._resolve_secret_refs(merged)
         return merged
+
+    def _resolve_secret_refs(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Resolve env: and file: secret references in config values.
+
+        Args:
+            config: Configuration dictionary with possible reference values.
+
+        Returns:
+            New dictionary with all references resolved to their actual values.
+            Literal (non-reference) values pass through unchanged.
+
+        Raises:
+            ValueError: If a reference prefix is unknown or a referenced
+                environment variable / file cannot be read.
+        """
+        resolved = {}
+        for key, value in config.items():
+            if not isinstance(value, str):
+                resolved[key] = value
+                continue
+
+            if value.startswith("env:"):
+                var_name = value[len("env:") :]
+                if not var_name:
+                    raise ValueError(f"Empty env: reference for key '{key}'")
+                env_val = os.getenv(var_name)
+                if env_val is None:
+                    raise ValueError(
+                        f"Environment variable '{var_name}' referenced in config key "
+                        f"'{key}' is not set"
+                    )
+                resolved[key] = env_val
+
+            elif value.startswith("file:"):
+                file_path = value[len("file:") :]
+                if not file_path:
+                    raise ValueError(f"Empty file: reference for key '{key}'")
+                try:
+                    file_val = Path(file_path).read_text(encoding="utf-8").rstrip("\n")
+                except FileNotFoundError:
+                    raise ValueError(
+                        f"Secret file '{file_path}' referenced in config key '{key}' not found"
+                    ) from None
+                except PermissionError:
+                    raise ValueError(
+                        f"Permission denied reading secret file '{file_path}' "
+                        f"referenced in config key '{key}'"
+                    ) from None
+                except OSError as e:
+                    raise ValueError(
+                        f"Error reading secret file '{file_path}' referenced in "
+                        f"config key '{key}': {e}"
+                    ) from None
+                resolved[key] = file_val
+
+            elif _looks_like_reference(value):
+                # Value looks like a reference (e.g. "vault:my-secret") but
+                # uses an unsupported prefix.
+                prefix = value.split(":", 1)[0] + ":"
+                raise ValueError(
+                    f"Unknown reference prefix '{prefix}' for key '{key}'. "
+                    f"Supported prefixes: {', '.join(sorted(_REF_PREFIXES))}"
+                )
+
+            else:
+                resolved[key] = value
+
+        return resolved
+
+    def _redact_secrets(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Return a copy of *config* with secret values replaced by ``'****'``.
+
+        This is safe for logging and error messages — it never leaks resolved
+        secret values.
+        """
+        return {key: ("****" if key in _SECRET_KEYS else value) for key, value in config.items()}
+
+    def _warn_literal_secrets(self, config: dict[str, Any]) -> None:
+        """Emit a lint-style warning when a secret key holds a literal value.
+
+        Literal secrets in committed config files are a security risk. Users
+        should use ``env:`` or ``file:`` references instead.
+        """
+        for key in _SECRET_KEYS:
+            value = config.get(key)
+            if value is not None and isinstance(value, str) and not _looks_like_reference(value):
+                self.logger.warning(
+                    "Literal %s found in config — consider using env: or file: "
+                    "reference instead for security",
+                    key,
+                )
 
     def _create_adapter_config(self, config_dict: dict[str, Any]) -> AdapterConfig:
         """Create AdapterConfig from dictionary."""
         if not config_dict:
             raise ValueError("No database configuration found")
+
+        # Log the config with secrets redacted
+        self.logger.debug("Creating adapter config: %s", self._redact_secrets(config_dict))
 
         # Extract required fields
         db_type = config_dict.get("type")

--- a/tests/test_secret_references.py
+++ b/tests/test_secret_references.py
@@ -13,7 +13,6 @@ Covers:
 import logging
 import os
 import tempfile
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -342,23 +341,24 @@ host = "snowflake.example.com"
 
     def test_load_config_with_file_ref(self, manager: DatabaseConfigManager) -> None:
         """Full load_config resolves file: references."""
-        toml_content = """
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".secret") as f:
+            f.write("file-password\n")
+            fpath = f.name
+        try:
+            toml_content = f"""
 [tool.t4t.database]
 type = "snowflake"
 user = "admin"
-password = "file:/tmp/test_secret_file"
+password = "file:{fpath}"
 host = "snowflake.example.com"
 """
-        toml_file = manager.project_root / "pyproject.toml"
-        toml_file.write_text(toml_content)
+            toml_file = manager.project_root / "pyproject.toml"
+            toml_file.write_text(toml_content)
 
-        secret_path = Path("/tmp/test_secret_file")
-        try:
-            secret_path.write_text("file-password\n")
             config = manager.load_config("default")
             assert config.password == "file-password"
         finally:
-            secret_path.unlink(missing_ok=True)
+            os.unlink(fpath)
 
     def test_t4t_env_override_still_works(self, manager: DatabaseConfigManager) -> None:
         """T4T_DB_PASSWORD env var overrides TOML env: reference in full flow."""

--- a/tests/test_secret_references.py
+++ b/tests/test_secret_references.py
@@ -1,0 +1,417 @@
+"""Tests for secret reference resolution in database configuration.
+
+Covers:
+- env:VAR reference resolution
+- file:/path reference resolution
+- Literal values pass through unchanged
+- Unknown reference prefix → ValueError
+- Redaction of secrets in log output
+- Literal secret warning
+- T4T_DB_* env var overrides still work
+"""
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from t4t.engine.config import DatabaseConfigManager
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager() -> DatabaseConfigManager:
+    """Return a DatabaseConfigManager with a temp project root."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield DatabaseConfigManager(project_root=tmpdir)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_secret_refs
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSecretRefs:
+    """Tests for _resolve_secret_refs()."""
+
+    def test_env_ref_resolved(self, manager: DatabaseConfigManager) -> None:
+        """env:VAR is replaced by the environment variable value."""
+        with patch.dict(os.environ, {"MY_DB_PW": "s3cret!"}, clear=False):
+            result = manager._resolve_secret_refs({"password": "env:MY_DB_PW"})
+        assert result == {"password": "s3cret!"}
+
+    def test_env_ref_missing_raises(self, manager: DatabaseConfigManager) -> None:
+        """Missing env var raises ValueError."""
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(ValueError, match="MY_MISSING_VAR"),
+        ):
+            manager._resolve_secret_refs({"password": "env:MY_MISSING_VAR"})
+
+    def test_env_ref_empty_name_raises(self, manager: DatabaseConfigManager) -> None:
+        """Empty env: reference raises ValueError."""
+        with pytest.raises(ValueError, match="Empty env: reference"):
+            manager._resolve_secret_refs({"password": "env:"})
+
+    def test_file_ref_resolved(self, manager: DatabaseConfigManager) -> None:
+        """file:/path is replaced by the file content (trailing newline stripped)."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".secret") as f:
+            f.write("my-token\n")
+            fpath = f.name
+        try:
+            result = manager._resolve_secret_refs({"token": f"file:{fpath}"})
+            assert result == {"token": "my-token"}
+        finally:
+            os.unlink(fpath)
+
+    def test_file_ref_no_trailing_newline(self, manager: DatabaseConfigManager) -> None:
+        """File content without trailing newline is read as-is."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".secret") as f:
+            f.write("no-newline-here")
+            fpath = f.name
+        try:
+            result = manager._resolve_secret_refs({"token": f"file:{fpath}"})
+            assert result == {"token": "no-newline-here"}
+        finally:
+            os.unlink(fpath)
+
+    def test_file_ref_missing_raises(self, manager: DatabaseConfigManager) -> None:
+        """Missing file raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            manager._resolve_secret_refs({"password": "file:/nonexistent/secret"})
+
+    def test_file_ref_empty_path_raises(self, manager: DatabaseConfigManager) -> None:
+        """Empty file: reference raises ValueError."""
+        with pytest.raises(ValueError, match="Empty file: reference"):
+            manager._resolve_secret_refs({"password": "file:"})
+
+    def test_literal_values_pass_through(self, manager: DatabaseConfigManager) -> None:
+        """Non-reference values are returned unchanged."""
+        config = {
+            "type": "snowflake",
+            "host": "myhost.snowflake.com",
+            "port": 443,
+            "user": "admin",
+        }
+        result = manager._resolve_secret_refs(config)
+        assert result == config
+
+    def test_non_string_values_pass_through(self, manager: DatabaseConfigManager) -> None:
+        """Non-string values (int, None) are returned unchanged."""
+        config = {"port": 443, "extra": None}
+        result = manager._resolve_secret_refs(config)
+        assert result == config
+
+    def test_unknown_prefix_raises(self, manager: DatabaseConfigManager) -> None:
+        """Unknown reference prefix raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown reference prefix"):
+            manager._resolve_secret_refs({"password": "vault:my-secret"})
+
+    def test_mixed_config(self, manager: DatabaseConfigManager) -> None:
+        """Mixed literal and reference values are handled correctly."""
+        with patch.dict(os.environ, {"SF_PW": "real-password"}, clear=False):
+            config = {
+                "type": "snowflake",
+                "user": "admin",
+                "password": "env:SF_PW",
+                "host": "snowflake.example.com",
+            }
+            result = manager._resolve_secret_refs(config)
+        assert result == {
+            "type": "snowflake",
+            "user": "admin",
+            "password": "real-password",
+            "host": "snowflake.example.com",
+        }
+
+    def test_env_ref_with_t4t_override(self, manager: DatabaseConfigManager) -> None:
+        """T4T_DB_* env var overrides a TOML env: reference.
+
+        This tests the full precedence: TOML has env: reference, but
+        T4T_DB_PASSWORD env var overrides it in _merge_configs.
+        """
+        with patch.dict(
+            os.environ,
+            {"SF_PW": "from-env-ref", "T4T_DB_PASSWORD": "from-override"},
+            clear=False,
+        ):
+            toml_config = {"password": "env:SF_PW"}
+            env_config = {"password": "from-override"}
+            merged = manager._merge_configs(toml_config, env_config)
+        assert merged["password"] == "from-override"
+
+
+# ---------------------------------------------------------------------------
+# _redact_secrets
+# ---------------------------------------------------------------------------
+
+
+class TestRedactSecrets:
+    """Tests for _redact_secrets()."""
+
+    def test_password_redacted(self, manager: DatabaseConfigManager) -> None:
+        """password key is redacted."""
+        result = manager._redact_secrets({"password": "s3cret"})
+        assert result["password"] == "****"
+
+    def test_token_redacted(self, manager: DatabaseConfigManager) -> None:
+        """token key is redacted."""
+        result = manager._redact_secrets({"token": "my-token"})
+        assert result["token"] == "****"
+
+    def test_secret_redacted(self, manager: DatabaseConfigManager) -> None:
+        """secret key is redacted."""
+        result = manager._redact_secrets({"secret": "my-secret"})
+        assert result["secret"] == "****"
+
+    def test_non_secret_keys_preserved(self, manager: DatabaseConfigManager) -> None:
+        """Non-secret keys are preserved as-is."""
+        config = {"type": "snowflake", "host": "example.com", "user": "admin"}
+        result = manager._redact_secrets(config)
+        assert result == config
+
+    def test_mixed_config(self, manager: DatabaseConfigManager) -> None:
+        """Mixed config redacts only secret keys."""
+        config = {
+            "type": "snowflake",
+            "password": "s3cret",
+            "host": "example.com",
+            "token": "abc123",
+        }
+        result = manager._redact_secrets(config)
+        assert result == {
+            "type": "snowflake",
+            "password": "****",
+            "host": "example.com",
+            "token": "****",
+        }
+
+
+# ---------------------------------------------------------------------------
+# _warn_literal_secrets
+# ---------------------------------------------------------------------------
+
+
+class TestWarnLiteralSecrets:
+    """Tests for _warn_literal_secrets()."""
+
+    def test_literal_password_warns(
+        self, manager: DatabaseConfigManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Literal password value triggers a warning."""
+        caplog.set_level(logging.WARNING)
+        manager._warn_literal_secrets({"password": "plaintext"})
+        assert any("Literal password" in msg for msg in caplog.messages)
+
+    def test_literal_token_warns(
+        self, manager: DatabaseConfigManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Literal token value triggers a warning."""
+        caplog.set_level(logging.WARNING)
+        manager._warn_literal_secrets({"token": "plaintext"})
+        assert any("Literal token" in msg for msg in caplog.messages)
+
+    def test_literal_secret_warns(
+        self, manager: DatabaseConfigManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Literal secret value triggers a warning."""
+        caplog.set_level(logging.WARNING)
+        manager._warn_literal_secrets({"secret": "plaintext"})
+        assert any("Literal secret" in msg for msg in caplog.messages)
+
+    def test_env_ref_does_not_warn(
+        self, manager: DatabaseConfigManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """env: reference does not trigger a warning."""
+        caplog.set_level(logging.WARNING)
+        manager._warn_literal_secrets({"password": "env:MY_PW"})
+        assert not caplog.messages
+
+    def test_file_ref_does_not_warn(
+        self, manager: DatabaseConfigManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """file: reference does not trigger a warning."""
+        caplog.set_level(logging.WARNING)
+        manager._warn_literal_secrets({"password": "file:/run/secrets/pw"})
+        assert not caplog.messages
+
+    def test_no_secret_keys_no_warning(
+        self, manager: DatabaseConfigManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Config without secret keys produces no warnings."""
+        caplog.set_level(logging.WARNING)
+        manager._warn_literal_secrets({"type": "snowflake", "host": "example.com"})
+        assert not caplog.messages
+
+    def test_none_value_no_warning(
+        self, manager: DatabaseConfigManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """None value for a secret key produces no warning."""
+        caplog.set_level(logging.WARNING)
+        manager._warn_literal_secrets({"password": None})
+        assert not caplog.messages
+
+
+# ---------------------------------------------------------------------------
+# Integration: _merge_configs with secret resolution
+# ---------------------------------------------------------------------------
+
+
+class TestMergeConfigsWithSecrets:
+    """Tests for _merge_configs() with secret reference resolution."""
+
+    def test_toml_env_ref_resolved_in_merge(self, manager: DatabaseConfigManager) -> None:
+        """env: reference in TOML config is resolved during merge."""
+        with patch.dict(os.environ, {"SF_PW": "resolved-pw"}, clear=False):
+            merged = manager._merge_configs(
+                {"password": "env:SF_PW", "type": "snowflake"},
+                {},
+            )
+        assert merged["password"] == "resolved-pw"
+
+    def test_t4t_override_takes_precedence(self, manager: DatabaseConfigManager) -> None:
+        """T4T_DB_PASSWORD env var overrides TOML env: reference."""
+        with patch.dict(
+            os.environ,
+            {"SF_PW": "from-toml-ref", "T4T_DB_PASSWORD": "from-override"},
+            clear=False,
+        ):
+            merged = manager._merge_configs(
+                {"password": "env:SF_PW", "type": "snowflake"},
+                {"password": "from-override"},
+            )
+        assert merged["password"] == "from-override"
+
+    def test_toml_file_ref_resolved_in_merge(self, manager: DatabaseConfigManager) -> None:
+        """file: reference in TOML config is resolved during merge."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".secret") as f:
+            f.write("file-secret\n")
+            fpath = f.name
+        try:
+            merged = manager._merge_configs(
+                {"password": f"file:{fpath}", "type": "snowflake"},
+                {},
+            )
+            assert merged["password"] == "file-secret"
+        finally:
+            os.unlink(fpath)
+
+    def test_literal_values_unchanged(self, manager: DatabaseConfigManager) -> None:
+        """Literal values in TOML config pass through unchanged."""
+        merged = manager._merge_configs(
+            {"type": "duckdb", "path": "/data/mydb.duckdb"},
+            {},
+        )
+        assert merged == {"type": "duckdb", "path": "/data/mydb.duckdb"}
+
+
+# ---------------------------------------------------------------------------
+# Integration: full load_config flow
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfigWithSecrets:
+    """End-to-end tests for load_config() with secret references."""
+
+    def test_load_config_with_env_ref(self, manager: DatabaseConfigManager) -> None:
+        """Full load_config resolves env: references."""
+        # Create a minimal pyproject.toml
+        toml_content = """
+[tool.t4t.database]
+type = "snowflake"
+user = "admin"
+password = "env:SF_PW"
+host = "snowflake.example.com"
+"""
+        toml_file = manager.project_root / "pyproject.toml"
+        toml_file.write_text(toml_content)
+
+        with patch.dict(os.environ, {"SF_PW": "real-password"}, clear=False):
+            config = manager.load_config("default")
+
+        assert config.type == "snowflake"
+        assert config.user == "admin"
+        assert config.password == "real-password"
+        assert config.host == "snowflake.example.com"
+
+    def test_load_config_with_file_ref(self, manager: DatabaseConfigManager) -> None:
+        """Full load_config resolves file: references."""
+        toml_content = """
+[tool.t4t.database]
+type = "snowflake"
+user = "admin"
+password = "file:/tmp/test_secret_file"
+host = "snowflake.example.com"
+"""
+        toml_file = manager.project_root / "pyproject.toml"
+        toml_file.write_text(toml_content)
+
+        secret_path = Path("/tmp/test_secret_file")
+        try:
+            secret_path.write_text("file-password\n")
+            config = manager.load_config("default")
+            assert config.password == "file-password"
+        finally:
+            secret_path.unlink(missing_ok=True)
+
+    def test_t4t_env_override_still_works(self, manager: DatabaseConfigManager) -> None:
+        """T4T_DB_PASSWORD env var overrides TOML env: reference in full flow."""
+        toml_content = """
+[tool.t4t.database]
+type = "snowflake"
+user = "admin"
+password = "env:SF_PW"
+host = "snowflake.example.com"
+"""
+        toml_file = manager.project_root / "pyproject.toml"
+        toml_file.write_text(toml_content)
+
+        with patch.dict(
+            os.environ,
+            {"SF_PW": "from-toml-ref", "T4T_DB_PASSWORD": "from-override"},
+            clear=False,
+        ):
+            config = manager.load_config("default")
+
+        assert config.password == "from-override"
+
+    def test_literal_password_warns_in_load(
+        self, manager: DatabaseConfigManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Literal password in TOML triggers warning during load."""
+        caplog.set_level(logging.WARNING)
+
+        toml_content = """
+[tool.t4t.database]
+type = "snowflake"
+password = "plaintext-password"
+"""
+        toml_file = manager.project_root / "pyproject.toml"
+        toml_file.write_text(toml_content)
+
+        manager.load_config("default")
+        assert any("Literal password" in msg for msg in caplog.messages)
+
+    def test_env_ref_no_warning(
+        self, manager: DatabaseConfigManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """env: reference does not trigger literal warning."""
+        caplog.set_level(logging.WARNING)
+
+        toml_content = """
+[tool.t4t.database]
+type = "snowflake"
+password = "env:SF_PW"
+"""
+        toml_file = manager.project_root / "pyproject.toml"
+        toml_file.write_text(toml_content)
+
+        with patch.dict(os.environ, {"SF_PW": "real-pw"}, clear=False):
+            manager.load_config("default")
+        assert not any("Literal" in msg for msg in caplog.messages)


### PR DESCRIPTION
## Summary

Implements issue #29: Secret references in connection config (`env:`/`file:` syntax).

### Changes

- **`t4t/engine/config.py`** — Added `_resolve_secret_refs()`, `_redact_secrets()`, `_warn_literal_secrets()`
- **`tests/test_secret_references.py`** — 33 new tests

### Features

- `password = "env:SNOWFLAKE_PW"` — resolves from environment variable
- `password = "file:/run/secrets/sf_pw"` — resolves from file content
- Literal values remain allowed for non-secrets
- Resolved secrets redacted in all log output (`****`)
- Lint-style warning when `password`/`token`/`secret` keys hold literal values
- `T4T_DB_*` env-var overrides still work (resolved after merge)
- Unknown reference prefixes (`vault:`, `aws-sm:`) raise clear error — extensible for future managers

### Testing

- 33/33 tests passing
- Ruff linting: all checks passed