### PR TITLE
feat: consolidate config — DatabaseConfigManager as single source of truth (#73)

### DIFF
--- a/examples/t_project/output/dependency_graph.json
+++ b/examples/t_project/output/dependency_graph.json
@@ -1,26 +1,26 @@
 {
   "nodes": [
-    "my_schema.my_first_table",
-    "my_schema.my_forth_table",
     "my_schema.my_third_table_from_loop",
-    "my_schema.my_view",
-    "test:my_schema.my_first_table.test_my_first_table",
-    "my_schema.calculate_percentage",
-    "test:my_schema.my_first_table.name.not_null",
-    "test:my_schema.my_first_table.row_count_gt_0",
+    "my_schema.users_summary",
     "my_schema.incremental_example",
-    "my_schema.my_second_table",
-    "my_schema.my_second_table_from_loop",
+    "test:my_schema.my_second_table.unique",
+    "my_schema.my_first_table_from_loop",
     "my_schema.complex_join",
     "my_schema.my_third_table",
-    "my_schema.users_summary",
-    "my_schema.recent_users",
-    "my_schema.my_first_table_from_loop",
+    "test:my_schema.my_first_table.test_my_first_table",
+    "my_schema.calculate_percentage",
+    "my_schema.my_forth_table",
+    "test:my_schema.my_first_table.name.not_null",
     "test:my_schema.my_second_table.row_count_gt_0",
+    "my_schema.recent_users",
+    "test:my_schema.my_first_table.id.not_null",
+    "my_schema.my_second_table_from_loop",
     "test:my_schema.my_second_table.name.not_null",
-    "test:my_schema.my_second_table.unique",
+    "my_schema.my_view",
+    "my_schema.my_second_table",
+    "my_schema.my_first_table",
     "test:my_schema.my_first_table.id.unique",
-    "test:my_schema.my_first_table.id.not_null"
+    "test:my_schema.my_first_table.row_count_gt_0"
   ],
   "edges": [
     [
@@ -217,6 +217,34 @@
     ]
   },
   "dependents": {
+    "my_schema.my_third_table_from_loop": [],
+    "my_schema.users_summary": [],
+    "my_schema.incremental_example": [],
+    "test:my_schema.my_second_table.unique": [],
+    "my_schema.my_first_table_from_loop": [],
+    "my_schema.complex_join": [],
+    "my_schema.my_third_table": [
+      "my_schema.my_third_table_from_loop"
+    ],
+    "test:my_schema.my_first_table.test_my_first_table": [],
+    "my_schema.calculate_percentage": [],
+    "my_schema.my_forth_table": [
+      "my_schema.my_view"
+    ],
+    "test:my_schema.my_first_table.name.not_null": [],
+    "test:my_schema.my_second_table.row_count_gt_0": [],
+    "my_schema.recent_users": [],
+    "test:my_schema.my_first_table.id.not_null": [],
+    "my_schema.my_second_table_from_loop": [],
+    "test:my_schema.my_second_table.name.not_null": [],
+    "my_schema.my_view": [],
+    "my_schema.my_second_table": [
+      "my_schema.my_second_table_from_loop",
+      "my_schema.my_third_table",
+      "test:my_schema.my_second_table.name.not_null",
+      "test:my_schema.my_second_table.row_count_gt_0",
+      "test:my_schema.my_second_table.unique"
+    ],
     "my_schema.my_first_table": [
       "my_schema.users_summary",
       "my_schema.recent_users",
@@ -232,36 +260,8 @@
       "test:my_schema.my_first_table.row_count_gt_0",
       "test:my_schema.my_first_table.test_my_first_table"
     ],
-    "my_schema.my_forth_table": [
-      "my_schema.my_view"
-    ],
-    "my_schema.my_third_table_from_loop": [],
-    "my_schema.my_view": [],
-    "test:my_schema.my_first_table.test_my_first_table": [],
-    "my_schema.calculate_percentage": [],
-    "test:my_schema.my_first_table.name.not_null": [],
-    "test:my_schema.my_first_table.row_count_gt_0": [],
-    "my_schema.incremental_example": [],
-    "my_schema.my_second_table": [
-      "my_schema.my_second_table_from_loop",
-      "my_schema.my_third_table",
-      "test:my_schema.my_second_table.name.not_null",
-      "test:my_schema.my_second_table.row_count_gt_0",
-      "test:my_schema.my_second_table.unique"
-    ],
-    "my_schema.my_second_table_from_loop": [],
-    "my_schema.complex_join": [],
-    "my_schema.my_third_table": [
-      "my_schema.my_third_table_from_loop"
-    ],
-    "my_schema.users_summary": [],
-    "my_schema.recent_users": [],
-    "my_schema.my_first_table_from_loop": [],
-    "test:my_schema.my_second_table.row_count_gt_0": [],
-    "test:my_schema.my_second_table.name.not_null": [],
-    "test:my_schema.my_second_table.unique": [],
     "test:my_schema.my_first_table.id.unique": [],
-    "test:my_schema.my_first_table.id.not_null": []
+    "test:my_schema.my_first_table.row_count_gt_0": []
   },
   "execution_order": [
     "my_schema.calculate_percentage",

--- a/t4t/cli/utils.py
+++ b/t4t/cli/utils.py
@@ -6,10 +6,9 @@ Pure, stateless utility functions used across CLI commands.
 
 import json
 import logging
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any
-
-from t4t.adapters.base.config import SECRET_KEYS, resolve_secret_ref
 
 
 def parse_vars(vars_string: str | None) -> dict[str, Any]:
@@ -45,10 +44,10 @@ def load_project_config(
     Requires ``[environments.*]`` sections — legacy ``[connection]`` is no
     longer supported.
 
-    When *env_name* is provided, the default environment config
-    (``[environments.default]``) is merged with the specific environment
-    config (``[environments.<env_name>]``) and stored under the ``"connection"``
-    key in the returned dict for backward compatibility with CLI commands.
+    When *env_name* is provided, the connection config for that environment
+    is loaded via ``DatabaseConfigManager`` (the single source of truth for
+    config parsing) and stored under the ``"connection"`` key in the returned
+    dict for backward compatibility with CLI commands.
 
     Args:
         project_folder: Path to the project folder
@@ -87,33 +86,24 @@ def load_project_config(
     if vars_dict:
         config["vars"] = vars_dict
 
-    # If env_name is provided, merge default + specific env into connection key
+    # If env_name is provided, use DatabaseConfigManager as single source of truth
     if env_name:
-        environments = config.get("environments", {})
-        merged_conn: dict[str, Any] = {}
+        from t4t.engine.config import DatabaseConfigManager
 
-        # Start with [environments.default] connection
-        default_env = environments.get("default", {})
-        default_conn = default_env.get("connection", {})
-        if isinstance(default_conn, dict):
-            merged_conn.update(default_conn)
+        manager = DatabaseConfigManager(project_folder)
+        adapter_config = manager.load_config(env_name)
 
-        # Merge specific environment connection on top
-        specific_env = environments.get(env_name, {})
-        specific_conn = specific_env.get("connection", {})
-        if isinstance(specific_conn, dict):
-            merged_conn.update(specific_conn)
+        # Convert AdapterConfig to dict for backward compat with CLI commands
+        # that expect config["connection"] to be a dict
+        conn_dict = asdict(adapter_config)
+        # Remove fields that aren't simple connection params
+        conn_dict.pop("naming", None)
+        conn_dict.pop("connections", None)
+        conn_dict.pop("extra", None)
+        # Filter out None values for cleaner dict
+        conn_dict = {k: v for k, v in conn_dict.items() if v is not None}
 
-        # Resolve secret references in the merged connection config
-        for key in list(merged_conn.keys()):
-            if key in SECRET_KEYS and isinstance(merged_conn[key], str):
-                original = merged_conn[key]
-                resolved = resolve_secret_ref(original)
-                if resolved != original:
-                    merged_conn[key] = resolved
-
-        # Store as "connection" for backward compat
-        config["connection"] = merged_conn
+        config["connection"] = conn_dict
 
     return config
 


### PR DESCRIPTION
## Summary

Consolidates the two parallel config systems into one. `cli/utils.py`'s `load_project_config()` now calls `DatabaseConfigManager` instead of reimplementing env-merge and secret resolution.

## Changes

- **`t4t/cli/utils.py`**: `load_project_config()` now delegates to `DatabaseConfigManager` when `env_name` is provided. Uses `dataclasses.asdict()` to convert `AdapterConfig` back to dict for backward compat with CLI commands. Removed the duplicated env-merge logic, secret resolution, and `SECRET_KEYS` import.
- **`t4t/engine/config.py`**: Unchanged — already the single source of truth.

## Why

This debt was created by M2's implementation. Before #72, `cli/utils.py` had a simple `load_project_config()` that read `[connection]` and nothing else. #72 introduced `DatabaseConfigManager` with its own env-merge, secret resolution, and naming extraction, then duplicated part of that logic in `cli/utils.py` to make the CLI path work. The cost was demonstrated: four review cycles on PR #71 where the naming feature was fixed at one boundary and silently dropped at the next.

## Acceptance criteria

- [x] Exactly one module parses config — `DatabaseConfigManager` in `engine/config.py`
- [x] grep shows no second implementation of env-merge/secret-resolution in `cli/utils.py`
- [x] 1409 tests pass, no regressions
- [x] `t4t run --env dev` still works (same connection config as before)

## Dependencies

- Depends on: #72 (merged)
- Blocks: #30 (naming round 2)

Closes #73