### PR TITLE
Add issue-refinement template and skill (codifies the #13/#14/#30 refinement lessons)

### DIFF
--- a/.claude/skills/t4t-issue-refinement/SKILL.md
+++ b/.claude/skills/t4t-issue-refinement/SKILL.md
@@ -11,11 +11,11 @@ ready to hand to an implementing agent.
 
 ## Why this exists
 
-Six PR rounds (#71-#75, 2026-07) shipped a feature that was completely
-inert every time, despite green component tests, because the issue that
-spawned it was never refined against real code before implementation
-started. The fixes were found later, in review, at far higher cost than
-finding them in the issue text would have been.
+Six PR rounds (2026-07) shipped a feature that was completely inert every
+time, despite green component tests, because the issue that spawned it
+was never refined against real code before implementation started. The
+fixes were found later, in review, at far higher cost than finding them
+in the issue text would have been.
 
 ## Procedure
 

--- a/.claude/skills/t4t-issue-refinement/SKILL.md
+++ b/.claude/skills/t4t-issue-refinement/SKILL.md
@@ -37,36 +37,59 @@ finding them in the issue text would have been.
    (does the reference tool's approach conflict with a decision this
    project already made?).
 
-4. **Trace real code paths.** For every mechanism the issue proposes,
+4. **Draft a usage example and show it to the user before going further —
+   this is a conversation checkpoint, not a documentation step you do
+   silently.** Write a concrete, realistic transcript: actual CLI
+   invocations, actual config, actual (hand-written, clearly-marked-
+   illustrative) output. Present it in your response and explicitly ask
+   whether it matches what they'd expect to type and see. Don't proceed to
+   settling the detailed design until you've done this — a command name or
+   output format is far cheaper to change right now than after
+   implementation, and the person who'll use this daily should react to
+   it first. If the issue has no direct developer-facing surface (a
+   foundational/library piece), say so and name which downstream issue's
+   usage example covers it instead — don't force one.
+
+5. **Trace real code paths.** For every mechanism the issue proposes,
    find the actual file:line in the current codebase it will touch or
    replace. A design that only exists in prose, never checked against
    what the code actually does, is how timing bugs and missing-case bugs
    (e.g. a fingerprinting feature hashing post-substitution text because
    nobody traced when substitution actually runs) get shipped.
 
-5. **Settle every "what happens when X" explicitly.** Missing state,
+6. **Settle every "what happens when X" explicitly.** Missing state,
    partial failure, combination with existing flags/selectors, explicit
    non-goals — write the answer into the issue, don't leave it for the
    implementer's judgment. If you're not sure, that uncertainty itself is
    a finding to report, not something to paper over with vague language.
 
-6. **Write the acceptance criteria as a real end-to-end test**, exercising
+7. **Write the acceptance criteria as a real end-to-end test**, exercising
    the actual CLI/command path against real (or fixture) state, not mocked
    internals. Then adversarially check the test itself: could it pass in a
    broken state? (A "command exits 0" assertion is worthless if the
    command has a separate bug where it always exits 0.)
 
-7. **Second pass on your own fix.** Before presenting a proposed fix as
+8. **Write the implementation steps as a numbered, ordered sequence, not
+   a task pile.** Each step names the file(s) it touches, what it
+   accomplishes, and how to verify that step alone before moving to the
+   next — infrastructure before logic, logic before composition,
+   composition before wiring, wiring before the final E2E proof. This
+   gives the implementing agent (and whoever reviews the PR) a way to
+   find exactly where things diverged, instead of discovering only at the
+   end that nothing actually works end to end. Last step is always: run
+   the acceptance-criteria test from the previous step.
+
+9. **Second pass on your own fix.** Before presenting a proposed fix as
    settled, try to state it as an exact mechanism — file, line, function.
    If you can't, you haven't verified it yet; go trace it for real. This
    step alone caught a fix that was both riskier than necessary and
    silently missing an entire code path, on an issue that had already
    been through one refinement round.
 
-8. **If refining an already-open issue**, edit the issue body directly
-   (don't just comment) so a reader gets the complete, current design in
-   one place — but note what changed and why, either in the edit itself
-   or a short comment, so the history stays legible.
+10. **If refining an already-open issue**, edit the issue body directly
+    (don't just comment) so a reader gets the complete, current design in
+    one place — but note what changed and why, either in the edit itself
+    or a short comment, so the history stays legible.
 
 ## Output
 

--- a/.claude/skills/t4t-issue-refinement/SKILL.md
+++ b/.claude/skills/t4t-issue-refinement/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: t4t-issue-refinement
+description: Refine a needs-design GitHub issue before it's handed to an implementing agent, following .github/ISSUE_TEMPLATE/needs-design.md. Use when asked to refine, scope, or prepare an issue for implementation in this repository, or when a "needs-design"-labeled issue is about to be assigned.
+---
+
+# t4t Issue Refinement
+
+Refine the given issue (a number, URL, or "the issue we're discussing")
+against `.github/ISSUE_TEMPLATE/needs-design.md` before it is considered
+ready to hand to an implementing agent.
+
+## Why this exists
+
+Six PR rounds (#71-#75, 2026-07) shipped a feature that was completely
+inert every time, despite green component tests, because the issue that
+spawned it was never refined against real code before implementation
+started. The fixes were found later, in review, at far higher cost than
+finding them in the issue text would have been.
+
+## Procedure
+
+1. **Read `.github/ISSUE_TEMPLATE/needs-design.md` first.** Its section
+   headers are the checklist; do not improvise a different structure.
+
+2. **Existing-state audit — actually grep, don't assume.** Search the
+   codebase for anything that already implements or overlaps the concept
+   this issue introduces, including anything that looks abandoned or
+   duplicated. Report what you find even if it means the issue's premise
+   needs to change.
+
+3. **Prior art, via primary sources.** If a comparable feature exists in a
+   tool this project's users likely know (dbt, SQLMesh, etc.), fetch the
+   actual current docs — don't rely on training-data memory, especially
+   for anything that may have shipped after your knowledge cutoff. Check
+   specifically for naming collisions (would reusing a term promise
+   behavior this project doesn't have?) and architecture mismatches
+   (does the reference tool's approach conflict with a decision this
+   project already made?).
+
+4. **Trace real code paths.** For every mechanism the issue proposes,
+   find the actual file:line in the current codebase it will touch or
+   replace. A design that only exists in prose, never checked against
+   what the code actually does, is how timing bugs and missing-case bugs
+   (e.g. a fingerprinting feature hashing post-substitution text because
+   nobody traced when substitution actually runs) get shipped.
+
+5. **Settle every "what happens when X" explicitly.** Missing state,
+   partial failure, combination with existing flags/selectors, explicit
+   non-goals — write the answer into the issue, don't leave it for the
+   implementer's judgment. If you're not sure, that uncertainty itself is
+   a finding to report, not something to paper over with vague language.
+
+6. **Write the acceptance criteria as a real end-to-end test**, exercising
+   the actual CLI/command path against real (or fixture) state, not mocked
+   internals. Then adversarially check the test itself: could it pass in a
+   broken state? (A "command exits 0" assertion is worthless if the
+   command has a separate bug where it always exits 0.)
+
+7. **Second pass on your own fix.** Before presenting a proposed fix as
+   settled, try to state it as an exact mechanism — file, line, function.
+   If you can't, you haven't verified it yet; go trace it for real. This
+   step alone caught a fix that was both riskier than necessary and
+   silently missing an entire code path, on an issue that had already
+   been through one refinement round.
+
+8. **If refining an already-open issue**, edit the issue body directly
+   (don't just comment) so a reader gets the complete, current design in
+   one place — but note what changed and why, either in the edit itself
+   or a short comment, so the history stays legible.
+
+## Output
+
+A refined issue body following the template's structure, plus a short
+summary to the user: what was added/changed, and — critically — what
+existing bug, duplicate code, or gap the refinement surfaced that they
+should know about even if it doesn't block this specific issue.

--- a/.claude/skills/t4t-issue-refinement/SKILL.md
+++ b/.claude/skills/t4t-issue-refinement/SKILL.md
@@ -58,10 +58,14 @@ in the issue text would have been.
    nobody traced when substitution actually runs) get shipped.
 
 6. **Settle every "what happens when X" explicitly.** Missing state,
-   partial failure, combination with existing flags/selectors, explicit
-   non-goals — write the answer into the issue, don't leave it for the
-   implementer's judgment. If you're not sure, that uncertainty itself is
-   a finding to report, not something to paper over with vague language.
+   partial failure, combination with existing flags/selectors — write the
+   answer into the issue, don't leave it for the implementer's judgment.
+   If you're not sure, that uncertainty itself is a finding to report, not
+   something to paper over with vague language. This is also where you
+   populate the template's **dedicated Non-goals section** (its last
+   section, not a line buried inside other prose) — every "we decided not
+   to do X here" belongs there, listed explicitly, so a reader doesn't
+   have to infer scope boundaries from what's merely absent.
 
 7. **Write the acceptance criteria as a real end-to-end test**, exercising
    the actual CLI/command path against real (or fixture) state, not mocked
@@ -89,7 +93,11 @@ in the issue text would have been.
 10. **If refining an already-open issue**, edit the issue body directly
     (don't just comment) so a reader gets the complete, current design in
     one place — but note what changed and why, either in the edit itself
-    or a short comment, so the history stays legible.
+    or a short comment, so the history stays legible. This requires
+    write/collaborator access to the repo; if you don't have it (e.g. an
+    external contributor), post the full refined body as a comment
+    instead, clearly marked as a proposed replacement for the issue body,
+    so a maintainer can apply it.
 
 ## Output
 

--- a/.github/ISSUE_TEMPLATE/needs-design.md
+++ b/.github/ISSUE_TEMPLATE/needs-design.md
@@ -1,0 +1,87 @@
+---
+name: Needs-design feature
+about: A feature substantial enough to need a refinement pass before implementation
+title: ""
+labels: needs-design
+---
+
+<!--
+This template exists because of a real, expensive lesson (2026-07, issues
+#13/#14/#19/#30, PRs #71-#78): a "needs-design" label alone did not stop an
+issue from going straight to implementation without the design actually
+being settled. The result was six review rounds where component tests
+passed and the feature was completely inert, because no boundary the
+config crossed was checked end-to-end.
+
+Every section below is required before this issue is assigned to an
+implementing agent — not a nice-to-have, not something the implementer
+fills in as they go. Delete this comment block once the issue is refined;
+leave the section headers.
+-->
+
+## Why
+
+What problem does this solve, and why now.
+
+## Existing-state audit
+
+Grep the codebase for anything that already implements or overlaps this
+concept — including dead/duplicate implementations. (Two real examples:
+a duplicate config-loading path in `cli/utils.py` vs `DatabaseConfigManager`,
+and a fully dead `IncrementalStateManager` duplicating `StateManager` —
+both found only by grepping before designing, not by reading the issue
+that prompted the feature.)
+
+```bash
+grep -rn "<relevant term>" t4t/
+```
+
+## Prior art (if a comparable feature exists elsewhere)
+
+If a similar feature exists in a tool your users are likely coming from
+(dbt, SQLMesh, etc.), look it up via primary sources — docs, changelogs —
+not memory. Two failure modes to check for specifically:
+- **Naming collisions**: does reusing a term create a false expectation?
+  (t4t's `state:modified` selector was renamed to `definition:changed`
+  after research showed dbt's newer "dbt State" means something broader —
+  keeping the old name would have promised behavior t4t doesn't have.)
+- **Architecture mismatches**: does the reference tool's approach conflict
+  with a decision t4t has already made? (SQLMesh's virtual/view-based
+  environments were explicitly not adopted — they'd reopen the per-env-
+  database decision in #30.)
+
+## Design decisions (settled, not proposed)
+
+Every "what happens when X" question resolved explicitly, with the
+reasoning — not left for the implementer to infer. Common categories that
+have bitten this project: behavior on missing/first-run state, behavior on
+partial failure, how a new selector/flag combines with existing ones,
+what's explicitly out of scope (write the non-goals down, don't just omit
+them).
+
+## Implementation constraints
+
+Trace the actual code paths this feature will touch — real file:line
+references, not a description of the feature in the abstract. This is
+what catches gaps that only exist in the real codebase, not in how the
+feature sounds when described (e.g. a fingerprinting feature that hashes
+already-variable-substituted SQL, found only by tracing the actual
+substitution call site and its timing relative to parsing).
+
+## Acceptance criteria — the merge gate
+
+A **concrete end-to-end test**, spelled out here (pseudocode is fine),
+that exercises the real CLI/command path and checks real physical output —
+not mocked internals. This is the single highest-leverage item in this
+template: every review round of the naming saga this template is named
+after had passing component tests and a completely inert feature, because
+nothing ran the actual command and checked where the result landed.
+
+Before finalizing: could this test pass in a broken state? (E.g. an
+assertion on "did the command exit 0" is worthless if the command has a
+pre-existing bug where it exits 0 on failure — check for that separately.)
+
+## Non-goals
+
+What this issue explicitly does not cover, and which other issue (if any)
+owns it instead.

--- a/.github/ISSUE_TEMPLATE/needs-design.md
+++ b/.github/ISSUE_TEMPLATE/needs-design.md
@@ -23,6 +23,26 @@ leave the section headers.
 
 What problem does this solve, and why now.
 
+## Usage example — show it, get feedback, before designing further
+
+Before writing the detailed design, draft a **concrete, realistic transcript**
+of a developer using this feature: actual CLI invocations, actual config
+snippets, actual (illustrative, hand-written — the feature doesn't exist yet)
+output. Mark it clearly as proposed, not real output.
+
+**Show this to the user directly and ask for usability feedback before
+proceeding to Design decisions below.** This is a required conversation
+checkpoint, not just documentation — it's far cheaper to change a command
+name or an output format while it's three lines of prose than after
+implementation, and the person who has to live with the UX daily is the
+one who should react to it first.
+
+If this issue is a foundational/library piece with no direct developer-
+facing surface (e.g. #13's fingerprint computation, which is only exposed
+indirectly through #14's selector), say so explicitly and point to which
+downstream issue's usage example will demonstrate it end-to-end — don't
+force an artificial CLI example onto a piece that doesn't have one.
+
 ## Existing-state audit
 
 Grep the codebase for anything that already implements or overlaps this
@@ -67,6 +87,20 @@ what catches gaps that only exist in the real codebase, not in how the
 feature sounds when described (e.g. a fingerprinting feature that hashes
 already-variable-substituted SQL, found only by tracing the actual
 substitution call site and its timing relative to parsing).
+
+## Implementation steps — an ordered path, not a task pile
+
+A **numbered sequence**, not an unordered checklist. Each step names the
+file(s) it touches, what it accomplishes, and how to verify *that step
+alone* before moving to the next — infrastructure before logic, logic
+before composition, composition before wiring, wiring before the final
+E2E proof. The point is to make each step independently checkable, so an
+implementing agent (or reviewer) can tell exactly where things went wrong
+instead of discovering at the end that "everything's done" but the
+feature doesn't work — the same failure mode the acceptance-criteria
+section below exists to catch at the finish line, applied throughout.
+
+The final step is always: run the acceptance-criteria E2E test.
 
 ## Acceptance criteria — the merge gate
 

--- a/.github/ISSUE_TEMPLATE/needs-design.md
+++ b/.github/ISSUE_TEMPLATE/needs-design.md
@@ -6,12 +6,12 @@ labels: needs-design
 ---
 
 <!--
-This template exists because of a real, expensive lesson (2026-07, issues
-#13/#14/#19/#30, PRs #71-#78): a "needs-design" label alone did not stop an
-issue from going straight to implementation without the design actually
-being settled. The result was six review rounds where component tests
-passed and the feature was completely inert, because no boundary the
-config crossed was checked end-to-end.
+This template exists because of a real, expensive lesson (2026-07): a
+"needs-design" label alone did not stop an issue from going straight to
+implementation without the design actually being settled. The result was
+six review rounds where component tests passed and the feature was
+completely inert, because no boundary the config crossed was checked
+end-to-end.
 
 Every section below is required before this issue is assigned to an
 implementing agent — not a nice-to-have, not something the implementer
@@ -38,10 +38,11 @@ implementation, and the person who has to live with the UX daily is the
 one who should react to it first.
 
 If this issue is a foundational/library piece with no direct developer-
-facing surface (e.g. #13's fingerprint computation, which is only exposed
-indirectly through #14's selector), say so explicitly and point to which
-downstream issue's usage example will demonstrate it end-to-end — don't
-force an artificial CLI example onto a piece that doesn't have one.
+facing surface (e.g. a fingerprint-computation function that's only
+exposed indirectly through a CLI selector built in a later issue), say so
+explicitly and point to which downstream issue's usage example will
+demonstrate it end-to-end — don't force an artificial CLI example onto a
+piece that doesn't have one.
 
 ## Existing-state audit
 
@@ -67,8 +68,8 @@ not memory. Two failure modes to check for specifically:
   keeping the old name would have promised behavior t4t doesn't have.)
 - **Architecture mismatches**: does the reference tool's approach conflict
   with a decision t4t has already made? (SQLMesh's virtual/view-based
-  environments were explicitly not adopted — they'd reopen the per-env-
-  database decision in #30.)
+  environments were explicitly not adopted — they'd reopen t4t's
+  per-environment-database separation model.)
 
 ## Design decisions (settled, not proposed)
 
@@ -107,9 +108,10 @@ The final step is always: run the acceptance-criteria E2E test.
 A **concrete end-to-end test**, spelled out here (pseudocode is fine),
 that exercises the real CLI/command path and checks real physical output —
 not mocked internals. This is the single highest-leverage item in this
-template: every review round of the naming saga this template is named
-after had passing component tests and a completely inert feature, because
-nothing ran the actual command and checked where the result landed.
+template: a feature can have passing component tests and be completely
+inert in the real command if nothing runs the actual command and checks
+where the result landed — this happened repeatedly, at real cost, before
+this requirement existed.
 
 Before finalizing: could this test pass in a broken state? (E.g. an
 assertion on "did the command exit 0" is worthless if the command has a

--- a/docs/development/code-review.md
+++ b/docs/development/code-review.md
@@ -8,6 +8,12 @@ where judgment is required.
 
 These guidelines are written to work for human and LLM reviewers alike.
 
+**This document reviews diffs.** For refining a `needs-design` issue
+*before* implementation starts, use `.github/ISSUE_TEMPLATE/needs-design.md`
+and the `t4t-issue-refinement` skill instead — cheaper to catch a design gap
+in an issue than after several PR rounds against inert code (see #13/#14/#30
+and the PR #71-#75 history for why this distinction earned its own doc).
+
 ## Before review: let the tools run
 
 ```bash

--- a/docs/development/code-review.md
+++ b/docs/development/code-review.md
@@ -10,9 +10,8 @@ These guidelines are written to work for human and LLM reviewers alike.
 
 **This document reviews diffs.** For refining a `needs-design` issue
 *before* implementation starts, use `.github/ISSUE_TEMPLATE/needs-design.md`
-and the `t4t-issue-refinement` skill instead — cheaper to catch a design gap
-in an issue than after several PR rounds against inert code (see #13/#14/#30
-and the PR #71-#75 history for why this distinction earned its own doc).
+and the `t4t-issue-refinement` skill instead — it's cheaper to catch a
+design gap in an issue than after several PR rounds against inert code.
 
 ## Before review: let the tools run
 


### PR DESCRIPTION
## Summary

Turns the lessons from refining #13/#14/#19/#30 and reviewing the #71–#75 naming-saga PR rounds into a reusable process, not just a memory of "be more careful next time."

## What's here

- **`.github/ISSUE_TEMPLATE/needs-design.md`** — required sections for any issue substantial enough to need design work before an implementing agent picks it up: existing-state audit, prior-art check (via primary sources, not memory), settled design decisions (not proposed ones), traced implementation constraints (real file:line, not abstract description), an end-to-end acceptance test as the merge gate, explicit non-goals.
- **`.claude/skills/t4t-issue-refinement/`** — runs that same checklist against an existing issue. Mirrors `t4t-code-review`, but for the earlier checkpoint: refine before code exists, review after.
- **`docs/development/code-review.md`** — one-paragraph cross-reference between the two.

## Why this template's sections, specifically

Every section maps to a concrete miss from this repo's own history, not a generic best practice:

| Section | What it would have caught |
|---|---|
| Existing-state audit | The config duplication (#73) and a fully dead `IncrementalStateManager` duplicating `StateManager` (found while refining #13) |
| Prior art via primary sources | The `state:modified` naming collision with dbt's newer, broader "dbt State" — found by fetching dbt's actual current docs, not from memory |
| Traced implementation constraints | #13's fingerprinting design initially hashed post-variable-substitution SQL — found by tracing the actual `orchestrator.py` substitution call site, not by re-reading the issue's prose |
| E2E acceptance test as merge gate | The whole #71–#75 saga: six rounds of green component tests against a completely inert feature, because nothing ran the real CLI and checked the real physical outcome |
| Adversarial check on the test itself | #75's own E2E test passed while a dependent model failed outright, because the assertion was weaker than it looked; #78 (exit-code-0-on-failure) was found the same way |

🤖 Generated with [Claude Code](https://claude.com/claude-code)