### PR TITLE
Issue-refinement process: require empirical verification of third-party claims

### DIFF
--- a/.claude/skills/t4t-issue-refinement/SKILL.md
+++ b/.claude/skills/t4t-issue-refinement/SKILL.md
@@ -83,12 +83,26 @@ in the issue text would have been.
    end that nothing actually works end to end. Last step is always: run
    the acceptance-criteria test from the previous step.
 
-9. **Second pass on your own fix.** Before presenting a proposed fix as
-   settled, try to state it as an exact mechanism — file, line, function.
-   If you can't, you haven't verified it yet; go trace it for real. This
-   step alone caught a fix that was both riskier than necessary and
-   silently missing an entire code path, on an issue that had already
-   been through one refinement round.
+9. **Second pass on your own fix — precision is not the same as correctness.**
+   Before presenting a proposed fix as settled, try to state it as an exact
+   mechanism — file, line, function. If you can't, you haven't verified it
+   yet; go trace it for real. This catches vague fixes, but it does **not**
+   catch a fix that is stated with complete precision and is simply wrong —
+   a claim like "database X supports SQL feature Y" can be exact and still
+   false. For any claim about a **third-party system's behavior** (a
+   database's SQL dialect support, a library's normalization rules, another
+   tool's documented feature), **test it directly against a real instance
+   when one is available** — a local, embeddable database costs nothing to
+   spin up — rather than trust general or training-time knowledge. A claim
+   that a widely-used embedded database supports the SQL-standard `IDENTITY`
+   column syntax the same way a large RDBMS does is exactly the kind of
+   precisely-stated, plausible, and wrong claim this step exists to catch;
+   testing it directly took one query and found it was false. When you
+   genuinely can't test something (no live credentials for a cloud
+   service), say so explicitly in the issue text — mark it as
+   asserted-from-documentation, not verified — so a reader knows which
+   claims to double-check first rather than trusting every sentence in the
+   issue with equal confidence.
 
 10. **If refining an already-open issue**, edit the issue body directly
     (don't just comment) so a reader gets the complete, current design in

--- a/.github/ISSUE_TEMPLATE/needs-design.md
+++ b/.github/ISSUE_TEMPLATE/needs-design.md
@@ -89,6 +89,17 @@ feature sounds when described (e.g. a fingerprinting feature that hashes
 already-variable-substituted SQL, found only by tracing the actual
 substitution call site and its timing relative to parsing).
 
+For any claim about **third-party system behavior** — a database's SQL
+dialect support, a library's normalization rules — test it directly
+against a real instance when one is available, don't state it from
+memory or documentation alone, however standard it seems. A precisely
+stated claim can still be false (a widely-used embedded database turned
+out not to support the same `IDENTITY` column syntax a large RDBMS uses —
+found only by running the actual query). Where you genuinely can't test
+something (no live credentials for a cloud service), say so explicitly
+and mark it as asserted-not-verified, so a reader knows what to
+double-check first.
+
 ## Implementation steps — an ordered path, not a task pile
 
 A **numbered sequence**, not an unordered checklist. Each step names the


### PR DESCRIPTION
## Summary

A review pass on an already-refined issue found a real bug: a design decision asserted uniform SQL `IDENTITY`-column support across three databases, stated precisely (exact syntax named), and simply wrong for one of them — found by running the query against a real connection, not by reading more carefully.

The existing "second pass on your own fix" step already asks for exact mechanisms (file, line, function), which catches vague claims. It doesn't catch a claim that's precise and false. This adds the missing check specifically for claims about third-party system behavior (database SQL support, library normalization rules, another tool's documented feature): test it against a real instance when one's available, and explicitly mark anything untestable (no live cloud credentials, etc.) as asserted rather than verified.

Applied to both `.claude/skills/t4t-issue-refinement/SKILL.md` (step 9) and `.github/ISSUE_TEMPLATE/needs-design.md` (Implementation constraints), so it's required whether an agent is following the skill or working straight from the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)