### PR TITLE
Structured JSON run logs with stable run_id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+Standing rules for working in this repository. Keep this file short — hard
+rules plus pointers. Detail and rationale live in the linked docs, not here.
+
+## Hard rules
+
+- **Use the `t4t` logging module for all run/CLI output — never raw
+  `print()` or ad hoc `typer.echo()`**, beyond one-off CLI argument-validation
+  errors. Get a logger with `logger = logging.getLogger(__name__)` and call
+  `logger.info(...)`/`logger.warning(...)`/`logger.error(...)`. Full
+  rationale, examples, and the exception's exact scope:
+  [`docs/development/contributing.md`](docs/development/contributing.md#logging-not-print-typerecho)
+  (Code Style section).
+- **Never interpolate secrets into a log message string.** Pass structured
+  data via `extra={...}` so `--log-format json`'s redaction
+  (`redact_secrets()`, applied centrally in `JSONFormatter`) can actually
+  catch it — a secret baked into the message text bypasses redaction
+  entirely. See [`docs/development/logging.md`](docs/development/logging.md).
+- **Never `git commit`, `git push`, or open a PR unless explicitly asked.**
+- **Never merge a PR yourself.**
+
+## Pointers
+
+- Logging conventions (detail): `docs/development/contributing.md` — Code
+  Style section.
+- JSON log schema (the six named lifecycle events): `docs/development/logging.md`.
+- Code review checklist, including logging-specific danger zones:
+  `docs/development/code-review.md`.
+- Contribution workflow, testing guidelines, project structure:
+  `docs/development/contributing.md`.
+- Architecture overview: `docs/development/architecture.md`.

--- a/docs/development/code-review.md
+++ b/docs/development/code-review.md
@@ -83,6 +83,15 @@ quickstart end-to-end" are different levels of evidence.
 - **Python version policy**: t4t tracks the newest stable Python (currently
   3.14). Flag compatibility shims, version checks, and `from __future__`
   imports — they are dead weight under this policy.
+- **Raw `print()`/`typer.echo()` instead of `logging`**: all run/CLI output
+  goes through `logging.getLogger(__name__)` (see `CLAUDE.md` and
+  `contributing.md`'s Code Style section) — flag new `print()`/`typer.echo()`
+  call sites outside the one-off CLI-argument-validation exception. Also flag
+  secrets (passwords, tokens) interpolated directly into a log message
+  string via f-string/`%s` — redaction (`redact_secrets()` in
+  `JSONFormatter`) only ever sees structured fields passed via `extra={...}`,
+  never the rendered message text, so a secret baked into the string bypasses
+  it entirely and will leak in `--log-format json` output.
 
 ## 4. Tests as evidence, not as presence
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -175,6 +175,59 @@ from t4t.parser import ProjectParser
 from t4t.engine import ExecutionEngine
 ```
 
+### Logging (not `print()`/`typer.echo()`)
+
+All run/CLI-visible output goes through the standard library `logging`
+module, not raw `print()` or ad hoc `typer.echo()`. This is enforced project
+convention (see the root `CLAUDE.md`), established in
+[GitHub issue #36](https://github.com/francescomucio/tee-for-transform/issues/36):
+before that issue, `t4t/executor.py` and the CLI command files used
+`print()`/`typer.echo()` directly, while most engine/adapter modules already
+used `logging.getLogger(__name__)` -- two parallel mechanisms, with the
+`logging` one silently going nowhere (no handler was wired up for it). The
+fix was to give every module the same one mechanism, with a single format
+decision (`t4t/observability/logging_setup.py`) instead of ~110 scattered
+gated call sites.
+
+**Pattern**: at the top of a module, `logger = logging.getLogger(__name__)`;
+call `logger.info(...)`/`logger.warning(...)`/`logger.error(...)` for
+anything a user should see. Never interpolate secrets (passwords, tokens)
+into the message string itself -- pass structured data via `extra={...}`
+instead, so redaction (`redact_secrets()`, applied centrally by
+`JSONFormatter`) can actually catch it; a value baked into the message text
+bypasses that entirely.
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+def execute_models(...):
+    logger.info(f"Running t4t on project: {project_folder}")
+    ...
+    # Good: structured data via extra, not string-interpolated.
+    logger.debug("Resolved connection configuration", extra={"connection_config": config})
+    # Bad: secrets end up in the message text, which redaction never touches.
+    logger.debug(f"Using config: {config}")
+```
+
+**The only exception**: one-off CLI argument-validation errors raised before
+any real work starts (e.g. a `ValueError` from bad `--select`/`--retry`
+combinations in `run.py`/`build.py`) may still use `typer.echo(..., err=True)`
+directly -- these are simple, immediate usage errors, not part of the
+run/build/test output stream.
+
+**Two output modes, one Formatter class each**: `--log-format text` (default,
+human-readable, byte-compatible with the pre-#36 `print()`/`typer.echo()`
+content) and `--log-format json` (one flat JSON object per stdout line,
+suitable for `| jq`). Which format renders a given `logger.*` call is
+decided once, in `TextFormatter`/`JSONFormatter`
+(`t4t/observability/logging_setup.py`) -- call sites never need to know or
+care which mode is active. See `docs/development/logging.md` for the full
+JSON event schema (the six named lifecycle events) and
+`docs/development/code-review.md`'s danger-zones section for what reviewers
+check for on this.
+
 ## Testing Guidelines
 
 ### Test Coverage

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -107,6 +107,24 @@ Same shape as `model_started`/`model_finished`, keyed by `model` (or
 | `duration_ms` | int | `run`/`build` only. |
 | `executed_tables` / `failed_tables` | int | `run`/`build` only, present on the normal-completion path. |
 
+## Tracebacks on crash
+
+When a log record carries `exc_info` (i.e. was logged from an `except`
+block via `logger.exception(...)`/`logger.error(..., exc_info=True)`), the
+two formatters render it differently, consistent with how each mode treats
+everything else:
+
+- **Text mode**: the formatted traceback is inlined into the same line's
+  message text (`msg\n<traceback>`), matching historical
+  `print()`/`traceback.print_exc()` output.
+- **JSON mode**: the formatted traceback is emitted as its own top-level
+  `exc_info` string field on that line's JSON object, keeping `msg` itself
+  free of embedded newlines/traceback text — the payload stays one valid
+  JSON object per line either way.
+
+See `TextFormatter.format()` / `JSONFormatter.format()` in
+`t4t/observability/logging_setup.py`.
+
 ## Redaction
 
 `--log-format json` redacts secret values (currently: any dict-valued

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -1,0 +1,117 @@
+# Structured logging (`--log-format`)
+
+t4t's `run`/`build`/`test` commands accept `--log-format text|json` (default
+`text`) and the `T4T_LOG_FORMAT` environment variable (same values). Both
+render the same underlying `logging` records — see
+`t4t/observability/logging_setup.py` for the implementation and
+`docs/development/contributing.md`'s Code Style section for the "always use
+`logging`, never raw `print()`" convention this depends on.
+
+## Text mode (default)
+
+Byte-compatible with t4t's historical `print()`/`typer.echo()` output, plus
+genuinely live per-model/per-test progress lines that did not exist before
+([issue #36](https://github.com/francescomucio/tee-for-transform/issues/36)):
+
+```
+$ t4t run myproject --env prod
+Running t4t on project: myproject
+Refreshing generated lookup models...
+  ▶ models/staging/stg_orders.sql
+  ✅ models/staging/stg_orders.sql (0.8s, 12,043 rows)
+  ▶ models/marts/fct_orders.sql
+  ✅ models/marts/fct_orders.sql (2.1s, 340,221 rows)
+Completed! Successfully executed: 2 tables
+```
+
+## JSON mode
+
+One JSON object per stdout line (JSONL) — flat, no nested envelope. Every
+line has `ts`/`level`/`msg`. Lines for the six *named lifecycle events*
+additionally carry a `type` field plus their own event-specific fields, all
+at the top level (no `.data.x` nesting):
+
+```
+$ t4t run myproject --env prod --log-format json | jq -c 'select(.type=="model_finished")'
+{"ts":"2026-07-23T09:14:03.925Z","level":"info","type":"model_finished","run_id":"3f2a1e4c-...","msg":"  ✅ models/staging/stg_orders.sql (0.8s, 12,043 rows)","model":"models/staging/stg_orders.sql","status":"success","duration_ms":812,"row_count":12043,"materialization":"incremental","error":null}
+```
+
+A generic diagnostic message (not one of the six named events) still renders
+as valid JSON — `ts`/`level`/`msg` are always present — just without a
+`type` field:
+
+```json
+{"ts": "2026-07-23T09:14:01.998Z", "level": "info", "msg": "Refreshing generated lookup models..."}
+```
+
+**Only the six named events below have a documented, stable schema.** Every
+other message is guaranteed to be valid JSON with `ts`/`level`/`msg`, but its
+exact wording and any additional fields are not part of a stable contract —
+don't build tooling that pattern-matches on non-`type`d `msg` text.
+
+## The six named lifecycle events
+
+| `type`           | Emitted from                                                        | When |
+|-------------------|----------------------------------------------------------------------|------|
+| `run_started`     | `t4t/cli/commands/run.py`, `build.py`, `test.py`                     | First line of the invocation |
+| `model_started`   | `t4t/engine/executors/model_executor.py` (`ModelExecutor.execute()`) | Immediately before a model executes |
+| `model_finished`  | same                                                                  | Immediately after a model finishes (success or failure) |
+| `test_started`    | `t4t/testing/executors/model_test_executor.py` / `function_test_executor.py` | Before a model's/function's tests run |
+| `test_finished`   | same                                                                  | After a model's/function's tests finish |
+| `run_finished`    | `t4t/cli/commands/run.py` / `build.py` / `test.py`                   | Last line of the invocation |
+
+Every event carries `run_id` — the same value across the whole invocation's
+event stream *and* the row appended to `.t4t/output/<env>/runs.sqlite` for
+that run (the join key: `select run_id from runs order by rowid desc limit 1`).
+
+### `run_started`
+
+| Field | Type | Notes |
+|---|---|---|
+| `run_id` | string (UUID) | Generated once, at the very start of the CLI command. |
+| `env` | string | Resolved environment name (e.g. `dev`, `prod`). |
+| `t4t_version` | string | |
+| `selection` | list[string] \| null | `--select` patterns, if any. |
+
+### `model_started`
+
+| Field | Type |
+|---|---|
+| `run_id` | string |
+| `model` | string — fully-qualified table name |
+
+### `model_finished`
+
+| Field | Type | Notes |
+|---|---|---|
+| `run_id` | string | |
+| `model` | string | |
+| `status` | `"success"` \| `"failed"` | |
+| `duration_ms` | int | Real per-model wall-clock time. |
+| `row_count` | int \| null | Null on failure or when unavailable. |
+| `materialization` | string \| null | `"table"`, `"view"`, `"incremental"`, etc. |
+| `error` | string \| null | Set when `status == "failed"`. |
+
+### `test_started` / `test_finished`
+
+Same shape as `model_started`/`model_finished`, keyed by `model` (or
+`function` for function-level tests), plus on `test_finished`: `status`,
+`duration_ms`, `total`, `passed`, `failed`.
+
+### `run_finished`
+
+| Field | Type | Notes |
+|---|---|---|
+| `run_id` | string | |
+| `status` | `"success"` \| `"failed"` \| `"warning"` \| `"error"` | `"error"` means the run raised before completing normally; `"warning"` is `t4t test`-specific (tests passed but produced warnings). |
+| `duration_ms` | int | `run`/`build` only. |
+| `executed_tables` / `failed_tables` | int | `run`/`build` only, present on the normal-completion path. |
+
+## Redaction
+
+`--log-format json` redacts secret values (currently: any dict-valued
+`extra` field's `password` key) before serializing — this is enforced once,
+centrally, in `JSONFormatter`, not at each call site. See
+`docs/development/contributing.md`'s Code Style section for why call sites
+must pass structured config via `extra={...}` rather than interpolating it
+into the message string (redaction never sees the rendered `msg`).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
     - parser-model-flow.md
     - development/contributing.md
     - development/code-review.md
+    - development/logging.md
     - development/migration-guides/index.md
     - Implementation Guides:
       - development/implementation-guides/on_schema_change_implementation.md

--- a/t4t/cli/commands/build.py
+++ b/t4t/cli/commands/build.py
@@ -4,6 +4,11 @@ Build command implementation.
 Builds models with interleaved test execution, stopping on test failures.
 """
 
+import logging
+import time
+import uuid
+from importlib.metadata import PackageNotFoundError, version
+
 import typer
 
 from t4t.cli.context import CommandContext
@@ -12,6 +17,15 @@ from t4t.engine.connection_manager import ConnectionManager
 from t4t.executor import build_models
 from t4t.parser.output.lookup_generator import generate_lookups
 from t4t.state import prepare_retry_select_patterns
+
+logger = logging.getLogger(__name__)
+
+
+def _t4t_version() -> str:
+    try:
+        return version("t4t")
+    except PackageNotFoundError:
+        return "0.0.0"
 
 
 def _pluralize(count: int, singular: str, plural: str | None = None) -> str:
@@ -40,8 +54,15 @@ def cmd_build(
     retry: bool = False,
     auto_resolve_level_conflicts: bool = True,
     env: str | None = None,
+    log_format: str = "text",
 ) -> None:
     """Execute the build command."""
+    # run_id is generated here, at the very start, so it can be threaded
+    # through build_models()/ModelExecutor and stamped on every event this
+    # invocation emits, including the very first one (run_started).
+    run_id = str(uuid.uuid4())
+    run_start_time = time.monotonic()
+
     try:
         ctx = CommandContext(
             project_folder=project_folder,
@@ -50,6 +71,7 @@ def cmd_build(
             select=select,
             exclude=exclude,
             env=env,
+            log_format=log_format,
         )
     except ValueError as e:
         typer.echo(
@@ -58,18 +80,27 @@ def cmd_build(
         )
         raise typer.Exit(1) from None
     connection_manager = None
+    run_finished_emitted = False
 
     try:
         if ctx.is_protected_env():
-            typer.echo(
-                typer.style("⚠️  PROTECTED ENVIRONMENT", fg=typer.colors.YELLOW, bold=True)
-                + f": {ctx.env_name}"
-            )
-        typer.echo(f"Building project: {project_folder}")
+            logger.info(f"⚠️  PROTECTED ENVIRONMENT: {ctx.env_name}")
+        # This is also the run_started lifecycle event: run_id must be the
+        # first thing t4t emits about this invocation.
+        logger.info(
+            f"Building project: {project_folder}",
+            extra={
+                "type": "run_started",
+                "run_id": run_id,
+                "env": ctx.env_name,
+                "t4t_version": _t4t_version(),
+                "selection": ctx.select_patterns,
+            },
+        )
         ctx.print_variables_info()
         ctx.print_selection_info()
 
-        typer.echo("Refreshing generated lookup models...")
+        logger.info("Refreshing generated lookup models...")
         generate_lookups(
             project_path=ctx.project_path,
             vars_dict=ctx.vars,
@@ -122,6 +153,7 @@ def cmd_build(
             exclude_patterns=ctx.exclude_patterns,
             project_config=ctx.config,
             env_name=ctx.env_name,
+            run_id=run_id,
         )
 
         # Calculate statistics
@@ -144,49 +176,64 @@ def cmd_build(
                 f"{len(executed_functions)} {_pluralize(len(executed_functions), 'function')}"
             )
 
+        status = "success" if failed_count == 0 and failed_tests == 0 else "failed"
+        duration_ms = int((time.monotonic() - run_start_time) * 1000)
+        completion_extra = {
+            "type": "run_finished",
+            "run_id": run_id,
+            "status": status,
+            "duration_ms": duration_ms,
+            "executed_tables": successful_count,
+            "failed_tables": failed_count,
+        }
+
+        # This is also the run_finished lifecycle event -- the run's last line.
         if parts:
-            typer.echo(f"\nCompleted! Successfully executed: {', '.join(parts)}")
+            logger.info(
+                f"\nCompleted! Successfully executed: {', '.join(parts)}", extra=completion_extra
+            )
         else:
-            typer.echo("\nCompleted!")
+            logger.info("\nCompleted!", extra=completion_extra)
+        run_finished_emitted = True
 
         if total_functions > 0:
-            typer.echo(
+            logger.info(
                 f"  ✅ Successful: {successful_count} {_pluralize(successful_count, 'table')}, {len(executed_functions)} {_pluralize(len(executed_functions), 'function')}"
             )
         else:
-            typer.echo(
+            logger.info(
                 f"  ✅ Successful: {successful_count} {_pluralize(successful_count, 'table')}"
             )
 
         if failed_count > 0:
-            typer.echo(f"  ❌ Failed: {failed_count} {_pluralize(failed_count, 'table')}")
+            logger.warning(f"  ❌ Failed: {failed_count} {_pluralize(failed_count, 'table')}")
         if failed_functions:
-            typer.echo(
+            logger.warning(
                 f"  ❌ Failed: {len(failed_functions)} {_pluralize(len(failed_functions), 'function')}"
             )
 
-        typer.echo(
+        logger.info(
             f"Tests: {passed_tests} passed, {failed_tests} failed out of {total_tests} total"
         )
 
         if failed_count > 0 or failed_tests > 0:
             if failed_count > 0:
-                typer.echo(f"  ❌ Failed models: {failed_count}")
+                logger.warning(f"  ❌ Failed models: {failed_count}")
             if failed_tests > 0:
-                typer.echo(f"  ❌ Failed tests: {failed_tests}")
+                logger.warning(f"  ❌ Failed tests: {failed_tests}")
             raise typer.Exit(1)
         else:
-            typer.echo(
+            logger.info(
                 f"  ✅ All {successful_count} {_pluralize(successful_count, 'table')} executed successfully!"
             )
             if executed_functions:
-                typer.echo(
+                logger.info(
                     f"  ✅ All {len(executed_functions)} {_pluralize(len(executed_functions), 'function')} deployed successfully!"
                 )
-            typer.echo(f"  ✅ All {total_tests} tests passed!")
+            logger.info(f"  ✅ All {total_tests} tests passed!")
 
         if ctx.verbose:
-            typer.echo(f"Analysis info: {results.get('analysis', {})}")
+            logger.info(f"Analysis info: {results.get('analysis', {})}")
 
     except KeyboardInterrupt:
         typer.echo("\n\n⚠️  Build interrupted by user")
@@ -194,6 +241,17 @@ def cmd_build(
     except Exception as e:
         ctx.handle_error(e)
     finally:
+        if not run_finished_emitted:
+            duration_ms = int((time.monotonic() - run_start_time) * 1000)
+            logger.info(
+                "Run failed",
+                extra={
+                    "type": "run_finished",
+                    "run_id": run_id,
+                    "status": "error",
+                    "duration_ms": duration_ms,
+                },
+            )
         # Cleanup
         if connection_manager:
             connection_manager.cleanup()

--- a/t4t/cli/commands/build.py
+++ b/t4t/cli/commands/build.py
@@ -157,7 +157,6 @@ def cmd_build(
         )
 
         # Calculate statistics
-        len(results["executed_tables"]) + len(results["failed_tables"])
         successful_count = len(results["executed_tables"])
         failed_count = len(results["failed_tables"])
         executed_functions = results.get("executed_functions", [])

--- a/t4t/cli/commands/run.py
+++ b/t4t/cli/commands/run.py
@@ -165,13 +165,11 @@ def cmd_run(
         )
 
         # Calculate statistics
-        len(results["executed_tables"]) + len(results["failed_tables"])
         successful_tables = len(results["executed_tables"])
         failed_tables = len(results["failed_tables"])
 
         executed_functions = results.get("executed_functions", [])
         failed_functions = results.get("failed_functions", [])
-        len(executed_functions) + len(failed_functions)
         successful_functions = len(executed_functions)
         failed_functions_count = len(failed_functions)
 
@@ -234,6 +232,9 @@ def cmd_run(
         if ctx.verbose:
             logger.info(f"Analysis info: {results.get('analysis', {})}")
 
+    except KeyboardInterrupt:
+        typer.echo("\n\n⚠️  Run interrupted by user")
+        raise typer.Exit(130) from None
     except Exception as e:
         ctx.handle_error(e)
     finally:

--- a/t4t/cli/commands/run.py
+++ b/t4t/cli/commands/run.py
@@ -2,6 +2,11 @@
 Run command implementation.
 """
 
+import logging
+import time
+import uuid
+from importlib.metadata import PackageNotFoundError, version
+
 import typer
 
 from t4t.cli.context import CommandContext
@@ -10,6 +15,15 @@ from t4t.engine.connection_manager import ConnectionManager
 from t4t.executor import execute_models
 from t4t.parser.output.lookup_generator import generate_lookups
 from t4t.state import prepare_retry_select_patterns
+
+logger = logging.getLogger(__name__)
+
+
+def _t4t_version() -> str:
+    try:
+        return version("t4t")
+    except PackageNotFoundError:
+        return "0.0.0"
 
 
 def _pluralize(count: int, singular: str, plural: str | None = None) -> str:
@@ -38,8 +52,16 @@ def cmd_run(
     retry: bool = False,
     auto_resolve_level_conflicts: bool = True,
     env: str | None = None,
+    log_format: str = "text",
 ) -> None:
     """Execute the run command."""
+    # run_id is generated here, at the very start, so it can be threaded
+    # through execute_models()/ModelExecutor and stamped on every event this
+    # invocation emits, including the very first one (run_started) — it must
+    # not be minted later (e.g. only when the run manifest is built).
+    run_id = str(uuid.uuid4())
+    run_start_time = time.monotonic()
+
     try:
         ctx = CommandContext(
             project_folder=project_folder,
@@ -48,6 +70,7 @@ def cmd_run(
             select=select,
             exclude=exclude,
             env=env,
+            log_format=log_format,
         )
     except ValueError as e:
         typer.echo(
@@ -56,18 +79,27 @@ def cmd_run(
         )
         raise typer.Exit(1) from None
     connection_manager = None
+    run_finished_emitted = False
 
     try:
         if ctx.is_protected_env():
-            typer.echo(
-                typer.style("⚠️  PROTECTED ENVIRONMENT", fg=typer.colors.YELLOW, bold=True)
-                + f": {ctx.env_name}"
-            )
-        typer.echo(f"Running t4t on project: {project_folder}")
+            logger.info(f"⚠️  PROTECTED ENVIRONMENT: {ctx.env_name}")
+        # This is also the run_started lifecycle event: run_id must be the
+        # first thing t4t emits about this invocation.
+        logger.info(
+            f"Running t4t on project: {project_folder}",
+            extra={
+                "type": "run_started",
+                "run_id": run_id,
+                "env": ctx.env_name,
+                "t4t_version": _t4t_version(),
+                "selection": ctx.select_patterns,
+            },
+        )
         ctx.print_variables_info()
         ctx.print_selection_info()
 
-        typer.echo("Refreshing generated lookup models...")
+        logger.info("Refreshing generated lookup models...")
         generate_lookups(
             project_path=ctx.project_path,
             vars_dict=ctx.vars,
@@ -129,6 +161,7 @@ def cmd_run(
             exclude_patterns=ctx.exclude_patterns,
             project_config=ctx.config,
             env_name=ctx.env_name,
+            run_id=run_id,
         )
 
         # Calculate statistics
@@ -151,42 +184,70 @@ def cmd_run(
         if successful_functions > 0:
             parts.append(f"{successful_functions} {_pluralize(successful_functions, 'function')}")
 
+        status = "success" if failed_tables == 0 and failed_functions_count == 0 else "failed"
+        duration_ms = int((time.monotonic() - run_start_time) * 1000)
+
+        # This is also the run_finished lifecycle event -- the run's last line.
+        completion_extra = {
+            "type": "run_finished",
+            "run_id": run_id,
+            "status": status,
+            "duration_ms": duration_ms,
+            "executed_tables": successful_tables,
+            "failed_tables": failed_tables,
+        }
         if parts:
-            typer.echo(f"\nCompleted! Successfully executed: {', '.join(parts)}")
+            logger.info(
+                f"\nCompleted! Successfully executed: {', '.join(parts)}", extra=completion_extra
+            )
         else:
-            typer.echo("\nCompleted!")
+            logger.info("\nCompleted!", extra=completion_extra)
+        run_finished_emitted = True
 
         # Show failures if any
         if failed_tables > 0 or failed_functions_count > 0 or warning_count > 0:
             if successful_tables > 0 or successful_functions > 0:
-                typer.echo(
+                logger.info(
                     f"  ✅ Successful: {successful_tables} {_pluralize(successful_tables, 'table')}, {successful_functions} {_pluralize(successful_functions, 'function')}"
                 )
             if failed_tables > 0:
-                typer.echo(f"  ❌ Failed: {failed_tables} {_pluralize(failed_tables, 'table')}")
+                logger.warning(f"  ❌ Failed: {failed_tables} {_pluralize(failed_tables, 'table')}")
             if failed_functions_count > 0:
-                typer.echo(
+                logger.warning(
                     f"  ❌ Failed: {failed_functions_count} {_pluralize(failed_functions_count, 'function')}"
                 )
             if warning_count > 0:
-                typer.echo(f"  ⚠️  Warnings: {warning_count} {_pluralize(warning_count, 'warning')}")
+                logger.warning(
+                    f"  ⚠️  Warnings: {warning_count} {_pluralize(warning_count, 'warning')}"
+                )
         elif successful_tables > 0 or successful_functions > 0:
             # All successful
             if successful_tables > 0:
-                typer.echo(
+                logger.info(
                     f"  ✅ All {successful_tables} {_pluralize(successful_tables, 'table')} executed successfully!"
                 )
             if successful_functions > 0:
-                typer.echo(
+                logger.info(
                     f"  ✅ All {successful_functions} {_pluralize(successful_functions, 'function')} deployed successfully!"
                 )
 
         if ctx.verbose:
-            typer.echo(f"Analysis info: {results.get('analysis', {})}")
+            logger.info(f"Analysis info: {results.get('analysis', {})}")
 
     except Exception as e:
         ctx.handle_error(e)
     finally:
+        if not run_finished_emitted:
+            duration_ms = int((time.monotonic() - run_start_time) * 1000)
+            logger.info(
+                "Run failed",
+                extra={
+                    "type": "run_finished",
+                    "run_id": run_id,
+                    "status": "error",
+                    "duration_ms": duration_ms,
+                },
+            )
         # Cleanup
         if connection_manager:
             connection_manager.cleanup()

--- a/t4t/cli/commands/test.py
+++ b/t4t/cli/commands/test.py
@@ -3,6 +3,8 @@ Test command implementation.
 """
 
 import contextlib
+import logging
+import uuid
 from pathlib import Path
 
 import typer
@@ -13,6 +15,8 @@ from t4t.engine.execution_engine import ExecutionEngine
 from t4t.parser import ProjectParser
 from t4t.testing import TestExecutor
 
+logger = logging.getLogger(__name__)
+
 
 def cmd_test(
     project_folder: str,
@@ -20,25 +24,37 @@ def cmd_test(
     verbose: bool = False,
     select: list[str] | None = None,
     exclude: list[str] | None = None,
+    log_format: str = "text",
 ) -> None:
     """Execute the test command."""
+    run_id = str(uuid.uuid4())
+
     ctx = CommandContext(
         project_folder=project_folder,
         vars=vars,
         verbose=verbose,
         select=select,
         exclude=exclude,
+        log_format=log_format,
     )
 
     try:
-        typer.echo(f"Running tests for project: {project_folder}")
+        logger.info(
+            f"Running tests for project: {project_folder}",
+            extra={
+                "type": "run_started",
+                "run_id": run_id,
+                "env": ctx.env_name,
+                "selection": ctx.select_patterns,
+            },
+        )
         ctx.print_variables_info()
         ctx.print_selection_info()
 
         # Step 1: Compile project to OTS modules
-        typer.echo("\n" + "=" * 50)
-        typer.echo("t4t: COMPILING PROJECT TO OTS MODULES")
-        typer.echo("=" * 50)
+        logger.info("\n" + "=" * 50)
+        logger.info("t4t: COMPILING PROJECT TO OTS MODULES")
+        logger.info("=" * 50)
         try:
             from t4t.compiler import compile_project
 
@@ -48,7 +64,7 @@ def cmd_test(
                 variables=ctx.vars,
                 project_config=ctx.config,
             )
-            typer.echo(
+            logger.info(
                 f"✅ Compilation complete: {compile_results['ots_modules_count']} OTS module(s)"
             )
 
@@ -60,11 +76,11 @@ def cmd_test(
             if not graph or not execution_order:
                 raise RuntimeError("Compilation did not return dependency graph or execution order")
 
-            typer.echo(f"✅ Using dependency graph from compilation: {len(graph['nodes'])} nodes")
-            typer.echo(f"   Execution order: {' -> '.join(execution_order)}")
+            logger.info(f"✅ Using dependency graph from compilation: {len(graph['nodes'])} nodes")
+            logger.info(f"   Execution order: {' -> '.join(execution_order)}")
 
         except Exception as e:
-            typer.echo(f"❌ Compilation failed: {e}", err=True)
+            logger.error(f"❌ Compilation failed: {e}")
             raise
 
         # Step 2: Create parser instance for test execution
@@ -81,7 +97,7 @@ def cmd_test(
             )
 
             parsed_models, execution_order = selector.filter_models(parsed_models, execution_order)
-            typer.echo(f"Filtered to {len(parsed_models)} models")
+            logger.info(f"Filtered to {len(parsed_models)} models")
 
         # Create model executor and initialize execution engine to get adapter
         # Resolve relative paths in connection config relative to project folder
@@ -101,12 +117,12 @@ def cmd_test(
 
             # Create test executor (discover SQL tests from tests/ folder)
             test_executor = TestExecutor(
-                execution_engine.adapter, project_folder=str(ctx.project_path)
+                execution_engine.adapter, project_folder=str(ctx.project_path), run_id=run_id
             )
 
-            typer.echo("\n" + "=" * 50)
-            typer.echo("EXECUTING TESTS")
-            typer.echo("=" * 50)
+            logger.info("\n" + "=" * 50)
+            logger.info("EXECUTING TESTS")
+            logger.info("=" * 50)
 
             # Get parsed functions if available; functions may not be
             # available, in which case continue with model tests only
@@ -122,35 +138,45 @@ def cmd_test(
             )
 
             # Print test results
-            typer.echo("\nTest Results:")
-            typer.echo(f"  Total tests: {test_results['total']}")
-            typer.echo(f"  ✅ Passed: {test_results['passed']}")
-            typer.echo(f"  ❌ Failed: {test_results['failed']}")
+            logger.info("\nTest Results:")
+            logger.info(f"  Total tests: {test_results['total']}")
+            logger.info(f"  ✅ Passed: {test_results['passed']}")
+            logger.info(f"  ❌ Failed: {test_results['failed']}")
 
             if test_results["warnings"]:
-                typer.echo(f"\n  ⚠️  Warnings ({len(test_results['warnings'])}):")
+                logger.warning(f"\n  ⚠️  Warnings ({len(test_results['warnings'])}):")
                 for warning in test_results["warnings"]:
-                    typer.echo(f"    - {warning}")
+                    logger.warning(f"    - {warning}")
 
             if test_results["errors"]:
-                typer.echo(f"\n  ❌ Errors ({len(test_results['errors'])}):")
+                logger.error(f"\n  ❌ Errors ({len(test_results['errors'])}):")
                 for error in test_results["errors"]:
-                    typer.echo(f"    - {error}")
+                    logger.error(f"    - {error}")
 
             # Show individual test results if verbose
             if ctx.verbose and test_results["test_results"]:
-                typer.echo("\nDetailed Results:")
+                logger.info("\nDetailed Results:")
                 for result in test_results["test_results"]:
-                    typer.echo(f"  {result}")
+                    logger.info(f"  {result}")
 
-            # Exit with error code if there are test errors
+            # Exit with error code if there are test errors -- the final
+            # message on each branch also carries the run_finished event.
             if test_results["errors"]:
-                typer.echo("\n❌ Test execution failed with errors", err=True)
+                logger.error(
+                    "\n❌ Test execution failed with errors",
+                    extra={"type": "run_finished", "run_id": run_id, "status": "failed"},
+                )
                 raise typer.Exit(1)
             elif test_results["warnings"]:
-                typer.echo("\n⚠️  Test execution completed with warnings")
+                logger.warning(
+                    "\n⚠️  Test execution completed with warnings",
+                    extra={"type": "run_finished", "run_id": run_id, "status": "warning"},
+                )
             else:
-                typer.echo("\n✅ All tests passed!")
+                logger.info(
+                    "\n✅ All tests passed!",
+                    extra={"type": "run_finished", "run_id": run_id, "status": "success"},
+                )
 
         finally:
             if execution_engine:

--- a/t4t/cli/commands/test.py
+++ b/t4t/cli/commands/test.py
@@ -4,6 +4,7 @@ Test command implementation.
 
 import contextlib
 import logging
+import time
 import uuid
 from pathlib import Path
 
@@ -28,6 +29,8 @@ def cmd_test(
 ) -> None:
     """Execute the test command."""
     run_id = str(uuid.uuid4())
+    run_start_time = time.monotonic()
+    run_finished_emitted = False
 
     ctx = CommandContext(
         project_folder=project_folder,
@@ -166,17 +169,20 @@ def cmd_test(
                     "\n❌ Test execution failed with errors",
                     extra={"type": "run_finished", "run_id": run_id, "status": "failed"},
                 )
+                run_finished_emitted = True
                 raise typer.Exit(1)
             elif test_results["warnings"]:
                 logger.warning(
                     "\n⚠️  Test execution completed with warnings",
                     extra={"type": "run_finished", "run_id": run_id, "status": "warning"},
                 )
+                run_finished_emitted = True
             else:
                 logger.info(
                     "\n✅ All tests passed!",
                     extra={"type": "run_finished", "run_id": run_id, "status": "success"},
                 )
+                run_finished_emitted = True
 
         finally:
             if execution_engine:
@@ -184,3 +190,19 @@ def cmd_test(
 
     except Exception as e:
         ctx.handle_error(e)
+    finally:
+        # Guarantees run_finished fires even if an exception happened before
+        # reaching one of the three normal-completion branches above (e.g.
+        # compile_project() failing) -- same run_finished_emitted + finally
+        # pattern as run.py/build.py.
+        if not run_finished_emitted:
+            duration_ms = int((time.monotonic() - run_start_time) * 1000)
+            logger.info(
+                "Run failed",
+                extra={
+                    "type": "run_finished",
+                    "run_id": run_id,
+                    "status": "error",
+                    "duration_ms": duration_ms,
+                },
+            )

--- a/t4t/cli/context.py
+++ b/t4t/cli/context.py
@@ -8,7 +8,7 @@ import typer
 
 from t4t.observability import configure_logging
 
-from .utils import load_project_config, parse_vars, setup_logging
+from .utils import load_project_config, parse_vars
 
 
 class CommandContext:
@@ -68,12 +68,15 @@ class CommandContext:
         # Check if the resolved environment is protected
         self._check_protected_env(project_folder, resolved_env, env)
 
-        # Set up logging: the pre-existing basicConfig-based stderr diagnostic
-        # stream (unchanged), plus the new stdout text/json CLI output stream
-        # (t4t.observability) filtered to the run/build/test call sites.
+        # Set up logging: a single call. configure_logging() installs both
+        # the legacy basicConfig-based stderr diagnostic handler (as its own
+        # first step, via _install_legacy_root_handler) and the new stdout
+        # text/json CLI output stream (t4t.observability), in that order,
+        # so the stderr-deduplication filter always has a handler to attach
+        # to -- no cross-function call-order dependency for a caller to get
+        # wrong. See t4t.observability.logging_setup.configure_logging.
         self.verbose = verbose
         self.log_format = log_format
-        setup_logging(self.verbose)
         configure_logging(log_format, self.verbose)
 
         # Resolve project folder to absolute path

--- a/t4t/cli/context.py
+++ b/t4t/cli/context.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import typer
 
+from t4t.observability import configure_logging
+
 from .utils import load_project_config, parse_vars, setup_logging
 
 
@@ -25,6 +27,7 @@ class CommandContext:
         select: list[str] | None = None,
         exclude: list[str] | None = None,
         env: str | None = None,
+        log_format: str = "text",
     ) -> None:
         """
         Initialize command context from parameters.
@@ -38,6 +41,8 @@ class CommandContext:
             env: Environment name (e.g. "dev", "prod") — if provided, the
                  connection config for that environment is loaded into
                  ``config["connection"]``. Defaults to "dev" if not specified.
+            log_format: "text" (default) or "json" — see
+                 ``t4t.observability.logging_setup`` for the format registry.
         """
         # Parse variables if provided
         self.vars = parse_vars(vars)
@@ -63,9 +68,13 @@ class CommandContext:
         # Check if the resolved environment is protected
         self._check_protected_env(project_folder, resolved_env, env)
 
-        # Set up logging
+        # Set up logging: the pre-existing basicConfig-based stderr diagnostic
+        # stream (unchanged), plus the new stdout text/json CLI output stream
+        # (t4t.observability) filtered to the run/build/test call sites.
         self.verbose = verbose
+        self.log_format = log_format
         setup_logging(self.verbose)
+        configure_logging(log_format, self.verbose)
 
         # Resolve project folder to absolute path
         self.project_path = Path(project_folder).resolve()

--- a/t4t/cli/main.py
+++ b/t4t/cli/main.py
@@ -47,16 +47,22 @@ def validate_format(value: str) -> OutputFormat:
 
 
 def validate_log_format(value: str) -> str:
-    """Validate --log-format option (text or json)."""
-    from t4t.observability.logging_setup import FORMATTERS
+    """Validate --log-format option (text or json).
 
-    normalized = value.lower()
-    if normalized not in FORMATTERS:
+    Normalization/validation logic lives entirely in
+    ``t4t.observability.logging_setup.resolve_log_format`` (called here with
+    ``strict=True``) -- this callback only adapts that function's
+    ``ValueError`` into the ``typer.BadParameter`` Typer expects, so there
+    is exactly one place that decides what counts as a valid log format.
+    """
+    from t4t.observability.logging_setup import resolve_log_format
+
+    try:
+        return resolve_log_format(value, strict=True)
+    except ValueError as e:
         raise typer.BadParameter(
-            typer.style("Error: ", fg=typer.colors.RED, bold=True)
-            + f"Invalid log format '{value}'. Must be one of: {', '.join(sorted(FORMATTERS))}."
-        )
-    return normalized
+            typer.style("Error: ", fg=typer.colors.RED, bold=True) + str(e)
+        ) from e
 
 
 def validate_database_type(value: str) -> DatabaseType:

--- a/t4t/cli/main.py
+++ b/t4t/cli/main.py
@@ -46,6 +46,19 @@ def validate_format(value: str) -> OutputFormat:
     return value  # type: ignore[return-value]
 
 
+def validate_log_format(value: str) -> str:
+    """Validate --log-format option (text or json)."""
+    from t4t.observability.logging_setup import FORMATTERS
+
+    normalized = value.lower()
+    if normalized not in FORMATTERS:
+        raise typer.BadParameter(
+            typer.style("Error: ", fg=typer.colors.RED, bold=True)
+            + f"Invalid log format '{value}'. Must be one of: {', '.join(sorted(FORMATTERS))}."
+        )
+    return normalized
+
+
 def validate_database_type(value: str) -> DatabaseType:
     """Validate database type option."""
     db_type = value.lower()
@@ -96,6 +109,13 @@ RETRY_OPTION = typer.Option(
     "--retry",
     help="Re-run models that failed or were skipped downstream in the last run (same as run:failed+).",
 )
+LOG_FORMAT_OPTION = typer.Option(
+    "text",
+    "--log-format",
+    envvar="T4T_LOG_FORMAT",
+    help="Output format: 'text' (default, human-readable) or 'json' (JSONL to stdout).",
+    callback=validate_log_format,
+)
 
 
 def _check_required_argument(ctx: typer.Context, _arg_name: str, arg_value: Any) -> None:
@@ -122,6 +142,7 @@ def run(
     env: str | None = typer.Option(
         None, "--env", help="Environment name (e.g. dev, prod). Defaults to 'dev'."
     ),
+    log_format: str = LOG_FORMAT_OPTION,
 ) -> None:
     """Parse and execute SQL models."""
     _check_required_argument(ctx, "project_folder", project_folder)
@@ -134,6 +155,7 @@ def run(
         retry=retry,
         auto_resolve_level_conflicts=auto_resolve_level_conflicts,
         env=env,
+        log_format=log_format,
     )
 
 
@@ -161,6 +183,7 @@ def test(
     vars: str | None = VARS_OPTION,
     select: list[str] | None = SELECT_OPTION,
     exclude: list[str] | None = EXCLUDE_OPTION,
+    log_format: str = LOG_FORMAT_OPTION,
 ) -> None:
     """Run data quality tests on models."""
     _check_required_argument(ctx, "project_folder", project_folder)
@@ -170,6 +193,7 @@ def test(
         verbose=verbose,
         select=select,
         exclude=exclude,
+        log_format=log_format,
     )
 
 
@@ -190,6 +214,7 @@ def build(
     env: str | None = typer.Option(
         None, "--env", help="Environment name (e.g. dev, prod). Defaults to 'dev'."
     ),
+    log_format: str = LOG_FORMAT_OPTION,
 ) -> None:
     """Build models with tests (stops on test failure)."""
     _check_required_argument(ctx, "project_folder", project_folder)
@@ -202,6 +227,7 @@ def build(
         retry=retry,
         auto_resolve_level_conflicts=auto_resolve_level_conflicts,
         env=env,
+        log_format=log_format,
     )
 
 

--- a/t4t/cli/utils.py
+++ b/t4t/cli/utils.py
@@ -5,7 +5,6 @@ Pure, stateless utility functions used across CLI commands.
 """
 
 import json
-import logging
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -126,6 +125,15 @@ def setup_logging(verbose: bool = False) -> None:
 
     Args:
         verbose: If True, set logging level to DEBUG, otherwise INFO
+
+    Note: this is now a thin wrapper kept for backward compatibility with
+    any external caller of this name. `t4t.observability.logging_setup.
+    configure_logging()` installs this same legacy root handler internally,
+    as its own first step -- CommandContext no longer calls this function
+    separately/first, precisely so nothing outside configure_logging() can
+    accidentally violate the ordering the exclusion-filter logic depends on
+    (see `t4t.observability.logging_setup._install_legacy_root_handler`).
     """
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(level=level, format="%(levelname)s - %(name)s - %(message)s")
+    from t4t.observability.logging_setup import _install_legacy_root_handler
+
+    _install_legacy_root_handler(verbose)

--- a/t4t/compiler.py
+++ b/t4t/compiler.py
@@ -100,7 +100,10 @@ def compile_project(
             imported_ots_modules=imported_ots_modules,
             format=format,
         )
-        print(f"✅ Built and exported {ots_modules_count} OTS module(s)")
+        logger.info(
+            f"✅ Built and exported {ots_modules_count} OTS module(s)",
+            extra={"cli_output": True},
+        )
 
         return {
             "success": True,
@@ -123,9 +126,10 @@ def compile_project(
 
 
 def _print_step(title: str) -> None:
-    print("\n" + "=" * 50)
-    print(title)
-    print("=" * 50)
+    marker = {"cli_output": True}
+    logger.info("\n" + "=" * 50, extra=marker)
+    logger.info(title, extra=marker)
+    logger.info("=" * 50, extra=marker)
 
 
 def _parse_project_models_and_functions(
@@ -137,13 +141,16 @@ def _parse_project_models_and_functions(
     _print_step("STEP 1: Parsing SQL and Python models and functions")
     parser = ProjectParser(project_folder, connection_config, variables, project_config)
     parsed_models = parser.collect_models()
-    print(f"✅ Parsed {len(parsed_models)} models from SQL/Python files")
+    logger.info(
+        f"✅ Parsed {len(parsed_models)} models from SQL/Python files",
+        extra={"cli_output": True},
+    )
 
     parsed_functions = parser.orchestrator.discover_and_parse_functions()
     if parsed_functions:
-        print(f"✅ Parsed {len(parsed_functions)} functions")
+        logger.info(f"✅ Parsed {len(parsed_functions)} functions", extra={"cli_output": True})
     else:
-        print("✅ No functions found")
+        logger.info("✅ No functions found", extra={"cli_output": True})
 
     return parser, parsed_models, parsed_functions
 
@@ -157,10 +164,10 @@ def _load_imported_ots_models(models_folder: Path) -> tuple[list[Path], dict[str
     imported_ots_models: dict[str, Any] = {}
 
     if not ots_files:
-        print("No imported OTS modules found")
+        logger.info("No imported OTS modules found", extra={"cli_output": True})
         return ots_files, imported_ots_models
 
-    print(f"Found {len(ots_files)} imported OTS module(s)")
+    logger.info(f"Found {len(ots_files)} imported OTS module(s)", extra={"cli_output": True})
     reader = OTSModuleReader()
     converter = OTSConverter()
 
@@ -183,11 +190,10 @@ def _load_imported_ots_models(models_folder: Path) -> tuple[list[Path], dict[str
                     f"Loaded {len(module_functions)} functions from OTS module {ots_file.name} (not yet integrated)"
                 )
 
-            print(f"  ✅ Loaded {ots_file.name}: {len(module_models)} transformations", end="")
+            line = f"  ✅ Loaded {ots_file.name}: {len(module_models)} transformations"
             if module_functions:
-                print(f" and {len(module_functions)} functions")
-            else:
-                print()
+                line += f" and {len(module_functions)} functions"
+            logger.info(line, extra={"cli_output": True})
         except (OTSValidationError, OTSModuleReaderError, OTSConverterError) as e:
             raise CompilationError(f"Failed to load imported OTS module {ots_file}: {e}") from e
         except Exception as e:
@@ -215,7 +221,7 @@ def _detect_transformation_conflicts(
             error_msg += f"  - {conflict}\n"
         raise CompilationError(error_msg)
 
-    print("✅ No conflicts detected")
+    logger.info("✅ No conflicts detected", extra={"cli_output": True})
 
 
 def _merge_models(
@@ -225,10 +231,11 @@ def _merge_models(
     all_models = parsed_models.copy()
     all_models.update(imported_ots_models)
 
-    print(
-        f"✅ Merged {len(parsed_models)} SQL/Python models with {len(imported_ots_models)} imported OTS transformations"
+    logger.info(
+        f"✅ Merged {len(parsed_models)} SQL/Python models with {len(imported_ots_models)} imported OTS transformations",
+        extra={"cli_output": True},
     )
-    print(f"   Total: {len(all_models)} transformations")
+    logger.info(f"   Total: {len(all_models)} transformations", extra={"cli_output": True})
     return all_models
 
 

--- a/t4t/engine/execution_engine.py
+++ b/t4t/engine/execution_engine.py
@@ -39,6 +39,7 @@ class ExecutionEngine:
         project_folder: str = ".",
         variables: dict[str, Any] | None = None,
         env_name: str | None = None,
+        run_id: str | None = None,
     ) -> None:
         """
         Initialize the execution engine.
@@ -49,6 +50,9 @@ class ExecutionEngine:
             project_folder: Project folder path for state management
             variables: Optional dictionary of variables for model execution
             env_name: Environment name for scoping state
+            run_id: Identity of the run, threaded into `ModelExecutor`
+                (executors package) so model_started/model_finished events
+                carry it.
         """
         self.config = config or load_database_config(config_name)
         self.adapter = get_adapter(self.config)
@@ -56,6 +60,7 @@ class ExecutionEngine:
         self.project_folder = project_folder
         self.variables = variables or {}
         self.env_name = env_name
+        self.run_id = run_id
 
         # Initialize components
         self.state_checker = StateChecker(project_folder, env_name=env_name)
@@ -71,6 +76,7 @@ class ExecutionEngine:
             self.metadata_extractor,
             self.state_checker,
             self.config,
+            run_id=self.run_id,
         )
         self.function_executor = FunctionExecutor(
             self.adapter, project_folder, self.metadata_extractor

--- a/t4t/engine/executor.py
+++ b/t4t/engine/executor.py
@@ -25,6 +25,7 @@ class ModelExecutor:
         config: AdapterConfig | dict[str, Any] | None = None,
         config_name: str = "default",
         env_name: str | None = None,
+        run_id: str | None = None,
     ) -> None:
         """
         Initialize the ModelExecutor.
@@ -34,9 +35,13 @@ class ModelExecutor:
             config: Database adapter configuration (AdapterConfig or dict, if None, loads from config files)
             config_name: Configuration name to load (if config is None)
             env_name: Environment name for scoping state
+            run_id: Identity of the run this executor belongs to, threaded
+                down to `ExecutionEngine`/`ModelExecutor` (executors package)
+                so per-model lifecycle events can carry it.
         """
         self.project_folder = project_folder
         self.env_name = env_name
+        self.run_id = run_id
 
         # Handle configuration
         if config is None:
@@ -122,6 +127,7 @@ class ModelExecutor:
             project_folder=self.project_folder,
             variables=variables,
             env_name=self.env_name,
+            run_id=self.run_id,
         )
 
         try:

--- a/t4t/engine/executors/model_executor.py
+++ b/t4t/engine/executors/model_executor.py
@@ -1,6 +1,7 @@
 """Model execution logic."""
 
 import logging
+import time
 from typing import Any
 
 from t4t.adapters.base.core import DatabaseAdapter
@@ -10,6 +11,42 @@ from ..metadata.metadata_extractor import MetadataExtractor
 from ..state.state_checker import StateChecker
 
 logger = logging.getLogger(__name__)
+
+
+def _emit_model_finished(
+    table_name: str,
+    run_id: str | None,
+    start_time: float,
+    status: str,
+    *,
+    row_count: int | None = None,
+    materialization: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Emit the model_finished lifecycle event for one model.
+
+    Module-level (not a closure inside `execute()`'s loop) so every argument
+    is explicit rather than captured from an enclosing scope that changes
+    each iteration.
+    """
+    duration_ms = int((time.monotonic() - start_time) * 1000)
+    if status == "success":
+        msg = f"  ✅ {table_name} ({duration_ms / 1000:.1f}s, {row_count:,} rows)"
+    else:
+        msg = f"  ❌ {table_name} failed ({duration_ms / 1000:.1f}s): {error}"
+    logger.info(
+        msg,
+        extra={
+            "type": "model_finished",
+            "run_id": run_id,
+            "model": table_name,
+            "status": status,
+            "duration_ms": duration_ms,
+            "row_count": row_count,
+            "materialization": materialization,
+            "error": error,
+        },
+    )
 
 
 class ModelExecutor:
@@ -24,6 +61,7 @@ class ModelExecutor:
         metadata_extractor: MetadataExtractor,
         state_checker: StateChecker,
         config: Any | None = None,
+        run_id: str | None = None,
     ) -> None:
         """
         Initialize the model executor.
@@ -36,6 +74,9 @@ class ModelExecutor:
             metadata_extractor: Metadata extractor instance
             state_checker: State checker instance
             config: Optional adapter config
+            run_id: Identity of the run this execution belongs to, stamped
+                on the model_started/model_finished events emitted from the
+                loop in `execute()` below.
         """
         self.adapter = adapter
         self.project_folder = project_folder
@@ -44,6 +85,7 @@ class ModelExecutor:
         self.metadata_extractor = metadata_extractor
         self.state_checker = state_checker
         self.config = config
+        self.run_id = run_id
         # Track schemas that have been processed for tag attachment
         self._processed_schemas: dict[str, dict[str, Any]] = {}
 
@@ -93,6 +135,16 @@ class ModelExecutor:
                 logger.debug(f"Skipping test node: {table_name}")
                 continue
 
+            # model_started: the one hook point for live per-model progress --
+            # there is no other place in the codebase that emits per-model
+            # events as they happen, everything else only sees the fully
+            # completed results dict.
+            logger.info(
+                f"  ▶ {table_name}",
+                extra={"type": "model_started", "run_id": self.run_id, "model": table_name},
+            )
+            model_start_time = time.monotonic()
+
             try:
                 logger.debug(f"Executing model: {table_name}")
 
@@ -100,6 +152,13 @@ class ModelExecutor:
                     logger.warning(f"Model {table_name} not found in parsed models")
                     results["failed_tables"].append(
                         {"table": table_name, "error": "Model not found in parsed models"}
+                    )
+                    _emit_model_finished(
+                        table_name,
+                        self.run_id,
+                        model_start_time,
+                        "failed",
+                        error="Model not found in parsed models",
                     )
                     continue
 
@@ -113,6 +172,13 @@ class ModelExecutor:
                 if not sql_query:
                     results["failed_tables"].append(
                         {"table": table_name, "error": "No SQL query found"}
+                    )
+                    _emit_model_finished(
+                        table_name,
+                        self.run_id,
+                        model_start_time,
+                        "failed",
+                        error="No SQL query found",
                     )
                     continue
 
@@ -179,11 +245,22 @@ class ModelExecutor:
                 logger.debug(
                     f"Successfully executed {table_name} (mapped to {mapped_name}) with {table_info['row_count']} rows"
                 )
+                _emit_model_finished(
+                    table_name,
+                    self.run_id,
+                    model_start_time,
+                    "success",
+                    row_count=table_info["row_count"],
+                    materialization=materialization,
+                )
 
             except Exception as e:
                 error_msg = f"Error executing {table_name}: {str(e)}"
                 logger.error(error_msg)
                 results["failed_tables"].append({"table": table_name, "error": str(e)})
+                _emit_model_finished(
+                    table_name, self.run_id, model_start_time, "failed", error=str(e)
+                )
                 results["execution_log"].append(
                     {"table": table_name, "status": "failed", "error": str(e)}
                 )

--- a/t4t/executor.py
+++ b/t4t/executor.py
@@ -34,6 +34,7 @@ def _try_persist_run_manifest(
     cli_args: dict[str, Any] | None = None,
     environment: str | None = None,
     protected: bool = False,
+    run_id: str | None = None,
 ) -> None:
     """Write last_run.json and append to runs.sqlite; failures are logged only."""
     logger = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ def _try_persist_run_manifest(
             function_names=function_names,
             environment=environment,
             protected=protected,
+            run_id=run_id,
         )
         backend = LocalStateBackend(Path(project_folder) / "output", env_name=environment)
         backend.append_run(manifest)
@@ -69,6 +71,7 @@ def execute_models(
     exclude_patterns: list[str] | None = None,
     project_config: dict[str, Any] | None = None,
     env_name: str | None = None,
+    run_id: str | None = None,
 ) -> dict[str, Any]:
     """
     Execute SQL models by compiling to OTS modules and running them in dependency order.
@@ -90,16 +93,41 @@ def execute_models(
         select_patterns: Optional list of patterns to select models
         exclude_patterns: Optional list of patterns to exclude models
         project_config: Optional project configuration
+        run_id: Identity of this run, used to correlate model_started/finished
+            events and the persisted run manifest. Generated here if not
+            provided by the caller (e.g. direct/programmatic use, tests) --
+            the CLI (`run.py`) always supplies one, generated at the very
+            start of the command, so it is available for the first line of
+            output.
 
     Returns:
         Dictionary containing execution results and analysis info
     """
     logger = logging.getLogger(__name__)
+    if run_id is None:
+        import uuid
+
+        run_id = str(uuid.uuid4())
+
+    # Diagnostic only (debug level, silent unless --verbose): the raw,
+    # *unredacted* connection config is passed via extra -- JSONFormatter is
+    # responsible for redacting it before serializing (see
+    # t4t.observability.logging_setup.JSONFormatter / redact_secrets()).
+    # Call sites are not expected to redact for themselves.
+    _config_for_log = (
+        connection_config
+        if isinstance(connection_config, dict)
+        else getattr(connection_config, "__dict__", {})
+    )
+    logger.debug(
+        "Resolved connection configuration",
+        extra={"connection_config": _config_for_log},
+    )
 
     # Step 0: Compile project to OTS modules first
-    print(f"\n{SECTION_SEPARATOR}")
-    print("t4t: COMPILING PROJECT TO OTS MODULES")
-    print(SECTION_SEPARATOR)
+    logger.info(f"\n{SECTION_SEPARATOR}")
+    logger.info("t4t: COMPILING PROJECT TO OTS MODULES")
+    logger.info(SECTION_SEPARATOR)
     try:
         compile_results = compile_project(
             project_folder=project_folder,
@@ -107,7 +135,9 @@ def execute_models(
             variables=variables,
             project_config=project_config,
         )
-        print(f"✅ Compilation complete: {compile_results['ots_modules_count']} OTS module(s)")
+        logger.info(
+            f"✅ Compilation complete: {compile_results['ots_modules_count']} OTS module(s)"
+        )
 
         # Extract and validate graph and execution order from compile results
         graph, execution_order, parsed_models = shared_helpers.validate_compile_results(
@@ -125,11 +155,11 @@ def execute_models(
 
     # Handle case when there are no models
     if not parsed_models and not execution_order:
-        print(f"\n{SECTION_SEPARATOR}")
-        print("EXECUTION RESULTS")
-        print(SECTION_SEPARATOR)
-        print("\n✅ No models to execute")
-        print("   Project compiled successfully with 0 models")
+        logger.info(f"\n{SECTION_SEPARATOR}")
+        logger.info("EXECUTION RESULTS")
+        logger.info(SECTION_SEPARATOR)
+        logger.info("\n✅ No models to execute")
+        logger.info("   Project compiled successfully with 0 models")
         empty = shared_helpers.create_empty_execution_results(graph)
         _try_persist_run_manifest(
             project_folder,
@@ -141,6 +171,7 @@ def execute_models(
             function_names=fnames or None,
             environment=env_name,
             protected=is_env_protected(project_folder, env_name),
+            run_id=run_id,
         )
         return empty
 
@@ -163,11 +194,11 @@ def execute_models(
         )
         filtered_count = len(filtered_parsed_models)
 
-        print(f"\nFiltered to {filtered_count} models (from {original_count} total)")
+        logger.info(f"\nFiltered to {filtered_count} models (from {original_count} total)")
         if filtered_count > 0:
-            print(f"Filtered execution order: {' -> '.join(filtered_execution_order)}")
+            logger.info(f"Filtered execution order: {' -> '.join(filtered_execution_order)}")
         else:
-            print("⚠️  No models matched the selection criteria!")
+            logger.warning("⚠️  No models matched the selection criteria!")
             empty = shared_helpers.create_empty_execution_results(
                 graph, warnings=["No models matched the selection criteria"]
             )
@@ -181,15 +212,18 @@ def execute_models(
                 function_names=fnames or None,
                 environment=env_name,
                 protected=is_env_protected(project_folder, env_name),
+                run_id=run_id,
             )
             return empty
 
     # Step 3: Execute models
-    print(f"\n{SECTION_SEPARATOR}")
-    print("EXECUTING SQL MODELS")
-    print(SECTION_SEPARATOR)
+    logger.info(f"\n{SECTION_SEPARATOR}")
+    logger.info("EXECUTING SQL MODELS")
+    logger.info(SECTION_SEPARATOR)
 
-    model_executor = ModelExecutor(project_folder, connection_config, env_name=env_name)
+    model_executor = ModelExecutor(
+        project_folder, connection_config, env_name=env_name, run_id=run_id
+    )
 
     try:
         # Execute models using the executor (pass filtered models if selection was applied)
@@ -203,42 +237,42 @@ def execute_models(
         # Step 4: Save analysis files if requested (after execution to include qualified SQL)
         if save_analysis:
             parser.save_to_json()
-            print("Analysis files saved to output folder")
+            logger.info("Analysis files saved to output folder")
 
         # Print detailed results
-        print(f"\n{SECTION_SEPARATOR}")
-        print("EXECUTION RESULTS")
-        print(SECTION_SEPARATOR)
+        logger.info(f"\n{SECTION_SEPARATOR}")
+        logger.info("EXECUTION RESULTS")
+        logger.info(SECTION_SEPARATOR)
 
         if results.get("executed_functions"):
-            print("\nSuccessfully executed functions:")
+            logger.info("\nSuccessfully executed functions:")
             for function in results["executed_functions"]:
-                print(f"  - {function}")
+                logger.info(f"  - {function}")
 
         if results.get("failed_functions"):
-            print("\nFailed functions:")
+            logger.warning("\nFailed functions:")
             for failure in results["failed_functions"]:
-                print(f"  - {failure['function']}: {failure['error']}")
+                logger.warning(f"  - {failure['function']}: {failure['error']}")
 
         if results["executed_tables"]:
-            print("\nSuccessfully executed tables:")
+            logger.info("\nSuccessfully executed tables:")
             for table in results["executed_tables"]:
                 table_info = results["table_info"].get(table, {})
                 row_count = table_info.get("row_count", 0)
-                print(f"  - {table}: {row_count} rows")
+                logger.info(f"  - {table}: {row_count} rows")
 
         if results["failed_tables"]:
-            print("\nFailed tables:")
+            logger.warning("\nFailed tables:")
             for failure in results["failed_tables"]:
-                print(f"  - {failure['table']}: {failure['error']}")
+                logger.warning(f"  - {failure['table']}: {failure['error']}")
 
         # Get database info
         try:
             db_info = model_executor.get_database_info()
             if db_info:
-                print("\nDatabase Info:")
-                print(f"  Type: {db_info.get('connection_type', 'Unknown')}")
-                print(f"  Connected: {db_info.get('is_connected', False)}")
+                logger.info("\nDatabase Info:")
+                logger.info(f"  Type: {db_info.get('connection_type', 'Unknown')}")
+                logger.info(f"  Connected: {db_info.get('is_connected', False)}")
         except Exception as e:
             logger.warning(f"Could not get database info: {e}")
             # Don't fail execution if we can't get database info
@@ -263,11 +297,12 @@ def execute_models(
             function_names=fnames or None,
             environment=env_name,
             protected=is_env_protected(project_folder, env_name),
+            run_id=run_id,
         )
         return results
 
     except Exception as e:
-        print(f"Error during execution: {e}")
+        logger.error(f"Error during execution: {e}")
         raise
 
 
@@ -280,6 +315,7 @@ def build_models(
     exclude_patterns: list[str] | None = None,
     project_config: dict[str, Any] | None = None,
     env_name: str | None = None,
+    run_id: str | None = None,
 ) -> dict[str, Any]:
     """
     Build models with interleaved test execution, stopping on test failures.
@@ -300,6 +336,8 @@ def build_models(
         select_patterns: Optional list of patterns to select models
         exclude_patterns: Optional list of patterns to exclude models
         project_config: Optional project configuration
+        run_id: Identity of this run (see `execute_models`'s docstring).
+            Generated here if not provided by the caller.
 
     Returns:
         Dictionary containing execution results and analysis info
@@ -308,15 +346,19 @@ def build_models(
         SystemExit: If tests fail with ERROR severity
     """
     logger = logging.getLogger(__name__)
+    if run_id is None:
+        import uuid
 
-    print(f"\n{SECTION_SEPARATOR}")
-    print("t4t: BUILDING MODELS WITH TESTS")
-    print(SECTION_SEPARATOR)
+        run_id = str(uuid.uuid4())
+
+    logger.info(f"\n{SECTION_SEPARATOR}")
+    logger.info("t4t: BUILDING MODELS WITH TESTS")
+    logger.info(SECTION_SEPARATOR)
 
     # Step 1: Compile project to OTS modules first
-    print(f"\n{SECTION_SEPARATOR}")
-    print("t4t: COMPILING PROJECT TO OTS MODULES")
-    print(SECTION_SEPARATOR)
+    logger.info(f"\n{SECTION_SEPARATOR}")
+    logger.info("t4t: COMPILING PROJECT TO OTS MODULES")
+    logger.info(SECTION_SEPARATOR)
     try:
         compile_results = compile_project(
             project_folder=project_folder,
@@ -324,7 +366,9 @@ def build_models(
             variables=variables,
             project_config=project_config,
         )
-        print(f"✅ Compilation complete: {compile_results['ots_modules_count']} OTS module(s)")
+        logger.info(
+            f"✅ Compilation complete: {compile_results['ots_modules_count']} OTS module(s)"
+        )
 
         # Extract and validate graph and execution order from compile results
         graph, execution_order, parsed_models = shared_helpers.validate_compile_results(
@@ -356,7 +400,9 @@ def build_models(
     from t4t.engine import ModelExecutor
     from t4t.engine.execution_engine import ExecutionEngine
 
-    temp_executor = ModelExecutor(project_folder, connection_config, env_name=env_name)
+    temp_executor = ModelExecutor(
+        project_folder, connection_config, env_name=env_name, run_id=run_id
+    )
     temp_executor.execution_engine = ExecutionEngine(
         temp_executor.config, project_folder=project_folder, variables=variables
     )
@@ -370,15 +416,15 @@ def build_models(
 
     # Handle case when there are no models
     if not parsed_models and not execution_order:
-        print(f"\n{SECTION_SEPARATOR}")
-        print("BUILD RESULTS")
-        print(SECTION_SEPARATOR)
-        print("\n✅ No models to build")
-        print("   Project compiled successfully with 0 models")
+        logger.info(f"\n{SECTION_SEPARATOR}")
+        logger.info("BUILD RESULTS")
+        logger.info(SECTION_SEPARATOR)
+        logger.info("\n✅ No models to build")
+        logger.info("   Project compiled successfully with 0 models")
         if seed_results["total_seeds"] > 0:
-            print(f"  Seeds loaded: {len(seed_results['loaded_tables'])}")
+            logger.info(f"  Seeds loaded: {len(seed_results['loaded_tables'])}")
             if seed_results["failed_tables"]:
-                print(f"  Seeds failed: {len(seed_results['failed_tables'])}")
+                logger.warning(f"  Seeds failed: {len(seed_results['failed_tables'])}")
         empty_results = shared_helpers.create_empty_build_results(graph)
         empty_results["seed_results"] = seed_results
         _try_persist_run_manifest(
@@ -391,13 +437,14 @@ def build_models(
             function_names=None,
             environment=env_name,
             protected=is_env_protected(project_folder, env_name),
+            run_id=run_id,
         )
         return empty_results
 
     # Step 2: Initialize executors
-    print(f"\n{SECTION_SEPARATOR}")
-    print("BUILDING MODELS AND TESTS")
-    print(SECTION_SEPARATOR)
+    logger.info(f"\n{SECTION_SEPARATOR}")
+    logger.info("BUILDING MODELS AND TESTS")
+    logger.info(SECTION_SEPARATOR)
 
     model_executor = None
     failed_models = set()
@@ -406,7 +453,12 @@ def build_models(
 
     try:
         model_executor, test_executor = build_helpers.initialize_build_executors(
-            project_folder, connection_config, variables, load_seeds=False, env_name=env_name
+            project_folder,
+            connection_config,
+            variables,
+            load_seeds=False,
+            env_name=env_name,
+            run_id=run_id,
         )
 
         # Evaluate Python models before execution
@@ -443,7 +495,7 @@ def build_models(
         # Step 4: Save analysis files if requested
         if save_analysis:
             parser.save_to_json()
-            print("\nAnalysis files saved to output folder")
+            logger.info("\nAnalysis files saved to output folder")
 
         # Step 5: Compile and return results
         results = build_helpers.compile_build_results(
@@ -470,13 +522,14 @@ def build_models(
             function_names=fn_build or None,
             environment=env_name,
             protected=is_env_protected(project_folder, env_name),
+            run_id=run_id,
         )
         return results
 
     except SystemExit:
         raise
     except Exception as e:
-        print(f"Error during build: {e}")
+        logger.error(f"Error during build: {e}")
         raise
     finally:
         # Always disconnect

--- a/t4t/executor_helpers/build_helpers.py
+++ b/t4t/executor_helpers/build_helpers.py
@@ -5,6 +5,7 @@ This module contains helper functions used by the build_models function
 to keep the main executor.py focused on the public API.
 """
 
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -15,6 +16,15 @@ from t4t.testing import TestExecutor, TestSeverity
 
 if TYPE_CHECKING:
     from t4t.adapters import AdapterConfig
+
+logger = logging.getLogger(__name__)
+
+# A single reusable marker for former print() call sites -- see
+# t4t.observability.logging_setup.GATED_LOGGER_NAMES: this module also has
+# other, pre-existing logger.warning() calls (e.g. in
+# execute_functions_in_build's except block) that must stay off stdout by
+# default, so only records carrying this marker are let through.
+_CLI_OUTPUT = {"cli_output": True}
 
 # Constants
 TEST_NODE_PREFIX = "test:"
@@ -50,7 +60,9 @@ def setup_build_context_from_compile(
         filtered_parsed_models, filtered_execution_order = selector.filter_models(
             parsed_models, execution_order
         )
-        print(f"\nAfter filtering: {len(filtered_parsed_models)} models selected")
+        logger.info(
+            f"\nAfter filtering: {len(filtered_parsed_models)} models selected", extra=_CLI_OUTPUT
+        )
         return parser, filtered_parsed_models, graph, filtered_execution_order
 
     return parser, parsed_models, graph, execution_order
@@ -62,6 +74,7 @@ def initialize_build_executors(
     variables: dict[str, Any] | None,
     load_seeds: bool = True,
     env_name: str | None = None,
+    run_id: str | None = None,
 ) -> tuple[ModelExecutor, TestExecutor]:
     """
     Initialize model and test executors and connect to database.
@@ -72,16 +85,21 @@ def initialize_build_executors(
         variables: Optional variables for SQL substitution
         load_seeds: Whether to load seeds (default: True). Set to False if seeds were already loaded.
         env_name: Environment name for scoping state
+        run_id: Identity of the run, threaded into the model executor (for
+            model_started/finished events) and the test executor (for
+            test_started/finished events).
 
     Returns:
         Tuple of (model_executor, test_executor)
     """
-    model_executor = ModelExecutor(project_folder, connection_config, env_name=env_name)
+    model_executor = ModelExecutor(
+        project_folder, connection_config, env_name=env_name, run_id=run_id
+    )
 
     from t4t.engine.execution_engine import ExecutionEngine
 
     model_executor.execution_engine = ExecutionEngine(
-        model_executor.config, project_folder=project_folder, variables=variables
+        model_executor.config, project_folder=project_folder, variables=variables, run_id=run_id
     )
 
     model_executor.execution_engine.connect()
@@ -91,7 +109,7 @@ def initialize_build_executors(
         _load_seeds_for_build(model_executor, project_folder)
 
     test_executor = TestExecutor(
-        model_executor.execution_engine.adapter, project_folder=project_folder
+        model_executor.execution_engine.adapter, project_folder=project_folder, run_id=run_id
     )
 
     return model_executor, test_executor
@@ -113,7 +131,7 @@ def _load_seeds_for_build(model_executor: ModelExecutor, project_folder: str) ->
     if not seed_files:
         return {"loaded_tables": [], "failed_tables": [], "total_seeds": 0}
 
-    print(f"\nLoading {len(seed_files)} seed file(s)...")
+    logger.info(f"\nLoading {len(seed_files)} seed file(s)...", extra=_CLI_OUTPUT)
 
     # Load seeds using the adapter
     seed_loader = SeedLoader(model_executor.execution_engine.adapter)
@@ -121,20 +139,22 @@ def _load_seeds_for_build(model_executor: ModelExecutor, project_folder: str) ->
 
     # Log results
     if seed_results["loaded_tables"]:
-        print(f"  ✅ Loaded {len(seed_results['loaded_tables'])} seed(s)")
+        logger.info(f"  ✅ Loaded {len(seed_results['loaded_tables'])} seed(s)", extra=_CLI_OUTPUT)
         for table in seed_results["loaded_tables"]:
             # Get table info to show row count
             try:
                 table_info = model_executor.execution_engine.adapter.get_table_info(table)
                 row_count = table_info.get("row_count", 0)
-                print(f"    - {table}: {row_count} rows")
+                logger.info(f"    - {table}: {row_count} rows", extra=_CLI_OUTPUT)
             except Exception as e:
-                print(f"    - {table} (could not get row count: {e})")
+                logger.info(f"    - {table} (could not get row count: {e})", extra=_CLI_OUTPUT)
 
     if seed_results["failed_tables"]:
-        print(f"  ⚠️  Failed to load {len(seed_results['failed_tables'])} seed(s)")
+        logger.warning(
+            f"  ⚠️  Failed to load {len(seed_results['failed_tables'])} seed(s)", extra=_CLI_OUTPUT
+        )
         for failure in seed_results["failed_tables"]:
-            print(f"    - {failure['file']}: {failure['error']}")
+            logger.warning(f"    - {failure['file']}: {failure['error']}", extra=_CLI_OUTPUT)
 
     return seed_results
 
@@ -177,7 +197,7 @@ def execute_single_model(
     model_executor: ModelExecutor,
 ) -> dict[str, Any]:
     """Execute a single model and return results."""
-    print(f"\n📦 Executing: {node_name}")
+    logger.info(f"\n📦 Executing: {node_name}", extra=_CLI_OUTPUT)
 
     model_results = model_executor.execution_engine.execute_models(
         {node_name: parsed_models[node_name]}, [node_name]
@@ -204,14 +224,14 @@ def handle_model_execution_result(
             (f["error"] for f in model_results["failed_tables"] if f["table"] == node_name),
             "Unknown error",
         )
-        print(f"  ❌ Model failed: {error_msg}")
+        logger.warning(f"  ❌ Model failed: {error_msg}", extra=_CLI_OUTPUT)
         mark_dependents_as_skipped(node_name, parser, skipped_models)
         return False
 
     # Model executed successfully
     table_info = model_results.get("table_info", {}).get(node_name, {})
     row_count = table_info.get("row_count", 0)
-    print(f"  ✅ Model executed: {row_count} rows")
+    logger.info(f"  ✅ Model executed: {row_count} rows", extra=_CLI_OUTPUT)
     return True
 
 
@@ -231,7 +251,7 @@ def execute_tests_for_model(
     if not metadata:
         return []
 
-    print(f"  🧪 Running tests for {node_name}...")
+    logger.info(f"  🧪 Running tests for {node_name}...", extra=_CLI_OUTPUT)
     test_results = test_executor.execute_tests_for_model(
         table_name=node_name,
         metadata=metadata,
@@ -257,7 +277,7 @@ def execute_tests_for_function(
     if not metadata:
         return []
 
-    print(f"  🧪 Running tests for {function_name}...")
+    logger.info(f"  🧪 Running tests for {function_name}...", extra=_CLI_OUTPUT)
     test_results = test_executor.execute_tests_for_function(
         function_name=function_name, metadata=metadata
     )
@@ -280,13 +300,15 @@ def handle_test_results(
 
     if error_failures:
         failed_models.add(node_name)
-        print(f"  ❌ Tests failed for {node_name}:")
+        logger.error(f"  ❌ Tests failed for {node_name}:", extra=_CLI_OUTPUT)
         for failure in error_failures:
             location = f"{node_name}.{failure.column_name}" if failure.column_name else node_name
-            print(f"    - {failure.test_name} on {location}: {failure.message}")
+            logger.error(
+                f"    - {failure.test_name} on {location}: {failure.message}", extra=_CLI_OUTPUT
+            )
 
         mark_dependents_as_skipped(node_name, parser, skipped_models)
-        print(f"\n❌ Build stopped: Tests failed for {node_name}")
+        logger.error(f"\n❌ Build stopped: Tests failed for {node_name}", extra=_CLI_OUTPUT)
         raise SystemExit(1)
 
     # Tests passed or only warnings
@@ -295,9 +317,11 @@ def handle_test_results(
         1 for r in test_results if not r.passed and r.severity == TestSeverity.WARNING
     )
     if warning_count > 0:
-        print(f"  ⚠️  Tests: {passed_count} passed, {warning_count} warnings")
+        logger.warning(
+            f"  ⚠️  Tests: {passed_count} passed, {warning_count} warnings", extra=_CLI_OUTPUT
+        )
     else:
-        print(f"  ✅ Tests: {passed_count} passed")
+        logger.info(f"  ✅ Tests: {passed_count} passed", extra=_CLI_OUTPUT)
 
     return True
 
@@ -388,14 +412,20 @@ def execute_functions_in_build(
     try:
         parsed_functions = parser.orchestrator.discover_and_parse_functions()
         if parsed_functions:
-            print(f"\n📦 Executing {len(parsed_functions)} function(s) before models...")
+            logger.info(
+                f"\n📦 Executing {len(parsed_functions)} function(s) before models...",
+                extra=_CLI_OUTPUT,
+            )
             function_results = model_executor.execution_engine.execute_functions(
                 parsed_functions, execution_order
             )
             if function_results.get("executed_functions"):
-                print(f"  ✅ Executed {len(function_results['executed_functions'])} function(s)")
+                logger.info(
+                    f"  ✅ Executed {len(function_results['executed_functions'])} function(s)",
+                    extra=_CLI_OUTPUT,
+                )
                 for func_name in function_results["executed_functions"]:
-                    print(f"    - {func_name}")
+                    logger.info(f"    - {func_name}", extra=_CLI_OUTPUT)
 
                     # Execute tests for this function
                     func_test_results = execute_tests_for_function(
@@ -409,19 +439,19 @@ def execute_functions_in_build(
                         all_test_results.extend(func_test_results)
 
             if function_results.get("failed_functions"):
-                print(
-                    f"  ⚠️  Failed to execute {len(function_results['failed_functions'])} function(s)"
+                logger.warning(
+                    f"  ⚠️  Failed to execute {len(function_results['failed_functions'])} function(s)",
+                    extra=_CLI_OUTPUT,
                 )
                 for failure in function_results["failed_functions"]:
-                    print(f"    - {failure['function']}: {failure['error']}")
+                    logger.warning(
+                        f"    - {failure['function']}: {failure['error']}", extra=_CLI_OUTPUT
+                    )
                 # Continue with models even if some functions failed
                 # Individual function failures are logged but don't stop the build
     except Exception as e:
         # If function discovery/parsing fails, log warning but continue
         # This allows builds to work even if function parsing has issues
-        import logging
-
-        logger = logging.getLogger(__name__)
         from t4t.parser.shared.exceptions import ParserError
 
         if isinstance(e, ParserError):
@@ -492,16 +522,16 @@ def execute_models_with_tests(
         except Exception as e:
             failed_models.add(node_name)
             error_msg = str(e)
-            print(f"  ❌ Model execution failed: {error_msg}")
+            logger.error(f"  ❌ Model execution failed: {error_msg}", extra=_CLI_OUTPUT)
             mark_dependents_as_skipped(node_name, parser, skipped_models)
-            print(f"\n❌ Build stopped: Model {node_name} failed")
+            logger.error(f"\n❌ Build stopped: Model {node_name} failed", extra=_CLI_OUTPUT)
             raise SystemExit(1) from None
 
 
 def print_build_summary(
     results: dict[str, Any], failed_models: set[str], skipped_models: dict[str, str]
 ) -> None:
-    """Print build summary."""
+    """Log the build summary (kept as `print_build_summary` for API compatibility)."""
     executed_tables = results["executed_tables"]
     executed_functions = results.get("executed_functions", [])
     failed_functions = results.get("failed_functions", [])
@@ -510,24 +540,26 @@ def print_build_summary(
         "seed_results", {"loaded_tables": [], "failed_tables": [], "total_seeds": 0}
     )
 
-    print("\n" + "=" * 50)
-    print("BUILD RESULTS")
-    print("=" * 50)
+    logger.info("\n" + "=" * 50, extra=_CLI_OUTPUT)
+    logger.info("BUILD RESULTS", extra=_CLI_OUTPUT)
+    logger.info("=" * 50, extra=_CLI_OUTPUT)
 
     # Seed information
     if seed_results["total_seeds"] > 0:
-        print(f"  Seeds loaded: {len(seed_results['loaded_tables'])}")
+        logger.info(f"  Seeds loaded: {len(seed_results['loaded_tables'])}", extra=_CLI_OUTPUT)
         if seed_results["failed_tables"]:
-            print(f"  Seeds failed: {len(seed_results['failed_tables'])}")
+            logger.warning(
+                f"  Seeds failed: {len(seed_results['failed_tables'])}", extra=_CLI_OUTPUT
+            )
 
-    print(f"  Models executed: {len(executed_tables)}")
-    print(f"  Models failed: {len(failed_models)}")
-    print(f"  Models skipped: {len(skipped_models)}")
+    logger.info(f"  Models executed: {len(executed_tables)}", extra=_CLI_OUTPUT)
+    logger.info(f"  Models failed: {len(failed_models)}", extra=_CLI_OUTPUT)
+    logger.info(f"  Models skipped: {len(skipped_models)}", extra=_CLI_OUTPUT)
     if executed_functions or failed_functions:
-        print(f"  Functions executed: {len(executed_functions)}")
+        logger.info(f"  Functions executed: {len(executed_functions)}", extra=_CLI_OUTPUT)
         if failed_functions:
-            print(f"  Functions failed: {len(failed_functions)}")
-    print(f"  Tests passed: {test_results['passed']}")
-    print(f"  Tests failed: {test_results['failed']}")
+            logger.warning(f"  Functions failed: {len(failed_functions)}", extra=_CLI_OUTPUT)
+    logger.info(f"  Tests passed: {test_results['passed']}", extra=_CLI_OUTPUT)
+    logger.info(f"  Tests failed: {test_results['failed']}", extra=_CLI_OUTPUT)
     if test_results["warnings"] > 0:
-        print(f"  Test warnings: {test_results['warnings']}")
+        logger.warning(f"  Test warnings: {test_results['warnings']}", extra=_CLI_OUTPUT)

--- a/t4t/observability/__init__.py
+++ b/t4t/observability/__init__.py
@@ -1,0 +1,23 @@
+"""Structured logging / CLI output for t4t.
+
+See :mod:`t4t.observability.logging_setup` for the format registry
+(``text``/``json``) and the handler wired up at CLI startup.
+"""
+
+from .logging_setup import (
+    CLI_OUTPUT_LOGGER_NAMES,
+    DEFAULT_LOG_FORMAT,
+    FORMATTERS,
+    JSONFormatter,
+    TextFormatter,
+    configure_logging,
+)
+
+__all__ = [
+    "CLI_OUTPUT_LOGGER_NAMES",
+    "DEFAULT_LOG_FORMAT",
+    "FORMATTERS",
+    "JSONFormatter",
+    "TextFormatter",
+    "configure_logging",
+]

--- a/t4t/observability/logging_setup.py
+++ b/t4t/observability/logging_setup.py
@@ -214,7 +214,21 @@ class _DynamicStdoutHandler(logging.StreamHandler):
     """
 
     def emit(self, record: logging.LogRecord) -> None:
-        self.stream = sys.stdout
+        stream = sys.stdout
+        if stream is None:
+            # sys.stdout can legitimately be None (e.g. pythonw.exe, or any
+            # environment that detaches/closes standard streams) -- without
+            # this guard, StreamHandler.emit() would try to write to a None
+            # stream and rely on its own except-Exception/handleError()
+            # fallback to avoid crashing, which prints a warning of its own
+            # and can itself raise if handleError() tries to write to
+            # sys.stderr (also unavailable here). Fall back to stderr, and
+            # if that is unavailable too, drop the record silently rather
+            # than raising -- there's nowhere sane left to put it.
+            stream = sys.stderr
+            if stream is None:
+                return
+        self.stream = stream
         super().emit(record)
 
 
@@ -273,12 +287,68 @@ class _ExcludeCuratedFilter(logging.Filter):
         return not _is_curated_record(record)
 
 
-def resolve_log_format(value: str | None) -> str:
-    """Normalize a requested format, falling back to the default for unknown values."""
-    if value is None:
-        return DEFAULT_LOG_FORMAT
-    normalized = value.strip().lower()
-    return normalized if normalized in FORMATTERS else DEFAULT_LOG_FORMAT
+def resolve_log_format(value: str | None, *, strict: bool = False) -> str:
+    """Normalize a requested log format string -- the single source of
+    truth for log-format normalization, used both by internal callers (e.g.
+    :func:`configure_logging`) and by the CLI's ``--log-format`` callback
+    (:func:`t4t.cli.main.validate_log_format`), so the two never drift into
+    subtly different normalization rules again (they used to: the CLI
+    callback only lowercased, this function also stripped whitespace, so
+    e.g. a stray-whitespace ``T4T_LOG_FORMAT=" json"`` env var would pass
+    here but fail CLI validation).
+
+    Args:
+        value: Raw format string (e.g. from ``--log-format``/
+            ``T4T_LOG_FORMAT``), or None.
+        strict: If True, raise :class:`ValueError` for a value that does not
+            normalize to a recognized format, instead of silently falling
+            back to :data:`DEFAULT_LOG_FORMAT`. Internal callers (e.g.
+            :func:`configure_logging`) must use the default, permissive
+            ``strict=False`` -- they run *after* CLI validation has already
+            had its chance to reject bad input, and must never raise on
+            their own. The CLI callback opts into ``strict=True`` so bad
+            user input is still rejected outright, as before.
+
+    Returns:
+        A key from :data:`FORMATTERS`.
+
+    Raises:
+        ValueError: If ``strict`` is True and ``value`` does not normalize
+            to a recognized format.
+    """
+    normalized = value.strip().lower() if value is not None else None
+    if normalized in FORMATTERS:
+        return normalized
+    if strict:
+        raise ValueError(
+            f"Invalid log format {value!r}. Must be one of: {', '.join(sorted(FORMATTERS))}."
+        )
+    return DEFAULT_LOG_FORMAT
+
+
+def _install_legacy_root_handler(verbose: bool) -> None:
+    """Ensure the pre-existing (predates this module), basicConfig-based
+    root handler exists, before anything else in :func:`configure_logging`
+    runs -- so :func:`_exclude_curated_records_from_other_root_handlers`
+    always has a handler to patch, regardless of call order.
+
+    This logic used to live only in ``t4t/cli/utils.py:setup_logging()``,
+    called *separately* by ``CommandContext.__init__`` and required to run
+    strictly before :func:`configure_logging` -- an implicit, unenforced
+    ordering dependency that, if a future edit ever swapped the two calls,
+    would silently reintroduce the duplicate-stderr-output bug (the
+    exclusion filter would have nothing to attach to, since
+    ``logging.basicConfig()`` is a no-op once *our* handler already exists
+    on root). Owning it here, as this function's first step, removes that
+    footgun by construction: there is exactly one function
+    (:func:`configure_logging`) callers need to invoke, and its own
+    internal ordering can't be violated from outside it.
+    ``t4t/cli/utils.py:setup_logging()`` is now a thin wrapper around this
+    same function, kept for backward compatibility with any external caller
+    of that public name.
+    """
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s - %(name)s - %(message)s")
 
 
 def _remove_previously_installed_handlers() -> None:
@@ -336,11 +406,19 @@ def configure_logging(log_format: str = DEFAULT_LOG_FORMAT, verbose: bool = Fals
       curated records a second time.
 
     This does not touch any other handler already attached to the root
-    logger beyond adding that filter -- e.g. the
-    ``logging.basicConfig``-installed handler from
-    ``t4t/cli/utils.py:setup_logging()`` keeps working exactly as before for
-    every record that isn't part of t4t's curated stdout stream.
+    logger beyond adding that filter -- e.g. the legacy
+    ``logging.basicConfig``-installed handler (installed by this function
+    itself, first -- see :func:`_install_legacy_root_handler`) keeps
+    working exactly as before for every record that isn't part of t4t's
+    curated stdout stream.
     """
+    # Must run before anything else below: _exclude_curated_records_from_
+    # other_root_handlers() needs the legacy handler to already exist.
+    # Owning this call here (rather than requiring some other function to
+    # run first) is what makes that guarantee unconditional -- see the
+    # docstring on _install_legacy_root_handler for the bug this replaced.
+    _install_legacy_root_handler(verbose)
+
     formatter_cls = FORMATTERS.get(resolve_log_format(log_format), TextFormatter)
 
     _remove_previously_installed_handlers()

--- a/t4t/observability/logging_setup.py
+++ b/t4t/observability/logging_setup.py
@@ -231,12 +231,46 @@ class _CliOutputFilter(logging.Filter):
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
-        if record.name in CLI_OUTPUT_LOGGER_NAMES:
-            return True
-        if record.name in GATED_LOGGER_NAMES:
-            extra = _extra_fields(record)
-            return "type" in extra or extra.get("cli_output") is True
-        return False
+        return _is_curated_record(record)
+
+
+def _is_curated_record(record: logging.LogRecord) -> bool:
+    """True for a record this module's own handler would print.
+
+    Used by :class:`_ExcludeCuratedFilter` to keep a *different*,
+    pre-existing handler on the root logger (e.g. the
+    ``logging.basicConfig``-installed one from ``t4t/cli/utils.py:
+    setup_logging()``, which predates this module and formats every record
+    it sees as ``LEVEL - name - msg`` to stderr) from also printing the same
+    content a second time.
+    """
+    if record.name in CLI_OUTPUT_LOGGER_NAMES:
+        return True
+    if record.name in GATED_LOGGER_NAMES:
+        extra = _extra_fields(record)
+        return "type" in extra or extra.get("cli_output") is True
+    return False
+
+
+class _ExcludeCuratedFilter(logging.Filter):
+    """Attached to any *other* handler already on the root logger so it does
+    not also print t4t's curated stdout content a second time.
+
+    Only :data:`GATED_LOGGER_NAMES` loggers need this: :data:`CLI_OUTPUT_LOGGER_NAMES`
+    loggers are detached from root entirely (``propagate=False``, see
+    :func:`configure_logging`) since their whole surface is curated content
+    with nothing else that needs to keep reaching other handlers. GATED_LOGGER_NAMES
+    loggers mix curated content with genuine, pre-existing diagnostic-only
+    logging on the *same* logger name, so they can't be blanket-detached
+    without also silencing that diagnostic content on its pre-existing
+    (e.g. stderr) destination -- this filter is the surgical alternative:
+    let everything from those loggers keep propagating and reaching other
+    handlers as before, just not the specific records our own handler
+    already printed.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return not _is_curated_record(record)
 
 
 def resolve_log_format(value: str | None) -> str:
@@ -247,6 +281,38 @@ def resolve_log_format(value: str | None) -> str:
     return normalized if normalized in FORMATTERS else DEFAULT_LOG_FORMAT
 
 
+def _remove_previously_installed_handlers() -> None:
+    """Remove any handler this module previously attached, wherever it put it."""
+    for logger_obj in [
+        logging.getLogger(),
+        *(logging.getLogger(n) for n in CLI_OUTPUT_LOGGER_NAMES),
+    ]:
+        for existing in list(logger_obj.handlers):
+            if getattr(existing, _HANDLER_MARKER, False):
+                logger_obj.removeHandler(existing)
+
+
+def _exclude_curated_records_from_other_root_handlers(handler: logging.Handler) -> None:
+    """Stop pre-existing (non-t4t) root handlers from also printing curated records.
+
+    ``t4t/cli/utils.py:setup_logging()`` calls ``logging.basicConfig(...)``,
+    which -- if nothing has installed a root handler yet -- attaches its own
+    plain ``StreamHandler`` (stderr, ``"LEVEL - name - msg"`` format) to the
+    root logger. GATED_LOGGER_NAMES loggers still propagate to root (see
+    :func:`configure_logging`), so without this, every curated record from
+    those modules would print twice: once via *this* module's handler
+    (correctly, once, to stdout) and once via that older handler (a raw,
+    unfiltered duplicate on stderr) -- doubling stderr output for a
+    successful run and falsifying "text output unchanged".
+    """
+    for other in logging.getLogger().handlers:
+        if other is handler:
+            continue
+        if any(isinstance(f, _ExcludeCuratedFilter) for f in other.filters):
+            continue
+        other.addFilter(_ExcludeCuratedFilter())
+
+
 def configure_logging(log_format: str = DEFAULT_LOG_FORMAT, verbose: bool = False) -> None:
     """Install the single stdout handler that renders t4t's run/build/test output.
 
@@ -254,17 +320,30 @@ def configure_logging(log_format: str = DEFAULT_LOG_FORMAT, verbose: bool = Fals
     repeatedly across a test session) -- a previous handler installed by
     this function is removed first so records are never emitted twice.
 
+    Two different attachment strategies, by design (see
+    :data:`CLI_OUTPUT_LOGGER_NAMES` / :data:`GATED_LOGGER_NAMES` docstrings):
+
+    * :data:`CLI_OUTPUT_LOGGER_NAMES` loggers get the handler attached
+      *directly* and stop propagating to root (``propagate=False``) --
+      their entire surface is curated content, so there is nothing else on
+      those loggers that needs to keep reaching other handlers.
+    * :data:`GATED_LOGGER_NAMES` loggers keep propagating to root as before
+      (they mix curated content with genuine, pre-existing diagnostic
+      logging that must keep reaching wherever it went before this issue);
+      the handler is attached to root to catch their curated records, and
+      any *other* pre-existing root handler gets an
+      :class:`_ExcludeCuratedFilter` so it does not also print those same
+      curated records a second time.
+
     This does not touch any other handler already attached to the root
-    logger (e.g. anything a host application configured); it only adds/
-    replaces the one handler this module owns.
+    logger beyond adding that filter -- e.g. the
+    ``logging.basicConfig``-installed handler from
+    ``t4t/cli/utils.py:setup_logging()`` keeps working exactly as before for
+    every record that isn't part of t4t's curated stdout stream.
     """
     formatter_cls = FORMATTERS.get(resolve_log_format(log_format), TextFormatter)
 
-    root_logger = logging.getLogger()
-
-    for existing in list(root_logger.handlers):
-        if getattr(existing, _HANDLER_MARKER, False):
-            root_logger.removeHandler(existing)
+    _remove_previously_installed_handlers()
 
     handler = _DynamicStdoutHandler(stream=sys.stdout)
     handler.setFormatter(formatter_cls())
@@ -272,7 +351,10 @@ def configure_logging(log_format: str = DEFAULT_LOG_FORMAT, verbose: bool = Fals
     handler.setLevel(logging.DEBUG if verbose else logging.INFO)
     setattr(handler, _HANDLER_MARKER, True)
 
+    root_logger = logging.getLogger()
     root_logger.addHandler(handler)
+    _exclude_curated_records_from_other_root_handlers(handler)
+
     # The root logger's own level must not gate the allowlisted loggers'
     # records before they even reach the handler above; each allowlisted
     # logger is set explicitly so verbosity is controlled by the handler,
@@ -280,3 +362,13 @@ def configure_logging(log_format: str = DEFAULT_LOG_FORMAT, verbose: bool = Fals
     # raise the effective level of every other logger in the hierarchy).
     for name in CLI_OUTPUT_LOGGER_NAMES | GATED_LOGGER_NAMES:
         logging.getLogger(name).setLevel(logging.DEBUG if verbose else logging.INFO)
+
+    # CLI_OUTPUT_LOGGER_NAMES: attach the same handler directly and stop
+    # propagating to root -- avoids the doubled-stderr-output bug for the
+    # modules whose whole logging surface is curated content, without
+    # needing a filter (nothing else on these loggers should ever print).
+    for name in CLI_OUTPUT_LOGGER_NAMES:
+        logger_obj = logging.getLogger(name)
+        if handler not in logger_obj.handlers:
+            logger_obj.addHandler(handler)
+        logger_obj.propagate = False

--- a/t4t/observability/logging_setup.py
+++ b/t4t/observability/logging_setup.py
@@ -1,0 +1,282 @@
+"""Structured logging setup for t4t CLI output.
+
+This module is the single place that decides *how* run/build/test output is
+rendered (``--log-format text|json`` / ``T4T_LOG_FORMAT``). It replaces the
+raw ``print()``/``typer.echo()`` calls that used to carry t4t's user-facing
+output, plus the handful of ad hoc `logging.basicConfig` calls, with one
+handler wired to the standard library ``logging`` hierarchy that
+``logging.getLogger(__name__)`` already uses throughout the codebase.
+
+Design (see GitHub issue #36 for the full rationale):
+
+* ``TextFormatter`` is a byte-compatible passthrough of ``record.getMessage()``
+  -- today's text output is unchanged for every pre-existing message.
+* ``JSONFormatter`` emits one flat JSON object per line (JSONL) to stdout.
+  Every line has ``ts``/``level``/``msg``. Only six named lifecycle events
+  (``run_started``, ``model_started``, ``model_finished``, ``test_started``,
+  ``test_finished``, ``run_finished``) additionally carry a ``type`` field
+  plus their own event-specific fields, passed via the stdlib ``extra={}``
+  mechanism -- no nested envelope, no custom event-bus abstraction.
+* Format selection is a ``name -> Formatter class`` registry (:data:`FORMATTERS`),
+  not an if/elif chain, so adding a new format later is a one-line addition.
+* Only records emitted by the modules in :data:`CLI_OUTPUT_LOGGER_NAMES` are
+  ever written to stdout by the handler this module installs. Every other
+  ``logging.getLogger(__name__)`` call site in the codebase (engine/adapter
+  internals, parser internals, etc.) keeps behaving exactly as it did before
+  this issue -- nothing about those call sites is removed or bypassed, they
+  are simply not part of the curated stdout stream. This is what keeps
+  "text output unchanged" true: before this issue, none of that internal
+  logging ever reached stdout either (see the issue's audit).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+from typing import Any
+
+from t4t.adapters.base.config import redact_secrets
+
+DEFAULT_LOG_FORMAT = "text"
+
+#: Logger names (``__name__`` of the CLI command modules and ``t4t.executor``)
+#: whose records are *unconditionally* eligible for the stdout text/JSON
+#: stream this module configures. Every message in these modules used to be
+#: a ``print()``/``typer.echo()`` call -- i.e. already, unconditionally, on
+#: stdout -- so the swap to ``logger.*`` preserves that without needing a
+#: second condition. Kept deliberately small: these are the modules whose
+#: *entire* pre-existing logging.getLogger(__name__) surface was print()/
+#: typer.echo() before this issue (constraint 4's scope), so nothing else
+#: in them could leak.
+CLI_OUTPUT_LOGGER_NAMES: frozenset[str] = frozenset(
+    {
+        "t4t.executor",
+        "t4t.cli.commands.run",
+        "t4t.cli.commands.build",
+        "t4t.cli.commands.test",
+    }
+)
+
+#: Logger names of modules that mix (a) messages this issue deliberately
+#: surfaces on stdout -- either a pre-existing print()/typer.echo() call
+#: site mechanically swapped to logger.*, tagged ``extra={"cli_output":
+#: True}`` at the call site, or one of the six named lifecycle events,
+#: tagged ``extra={"type": ...}`` -- with (b) *other*, pre-existing
+#: ``logging.getLogger(__name__)`` calls that were never on stdout before
+#: (e.g. compiler.py's test-library-merge diagnostics, or
+#: "Starting execution of N models..." in model_executor.py). Only records
+#: carrying one of those two markers are let through; everything else from
+#: these loggers is filtered out, exactly as it was before this issue wired
+#: up a handler (it's still visible on stderr via the pre-existing
+#: logging.basicConfig-based setup, unaffected by this issue).
+GATED_LOGGER_NAMES: frozenset[str] = frozenset(
+    {
+        "t4t.compiler",
+        "t4t.executor_helpers.build_helpers",
+        "t4t.parser.output.json_exporter",
+        "t4t.parser.output.report_generator",
+        "t4t.engine.executors.model_executor",
+        "t4t.testing.executors.model_test_executor",
+        "t4t.testing.executors.function_test_executor",
+    }
+)
+
+#: LogRecord attributes that exist on every record regardless of what the
+#: call site passed via ``extra={}``. Anything else found on the record is
+#: treated as a structured field the call site deliberately attached.
+_STANDARD_RECORD_ATTRS: frozenset[str] = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "taskName",
+        "message",
+    }
+)
+
+
+def _extra_fields(record: logging.LogRecord) -> dict[str, Any]:
+    """Return the caller-supplied ``extra={...}`` fields attached to *record*."""
+    return {
+        key: value for key, value in record.__dict__.items() if key not in _STANDARD_RECORD_ATTRS
+    }
+
+
+def _redact(value: Any) -> Any:
+    """Redact secret values in *value* before it is serialized.
+
+    Applies :func:`redact_secrets` to any dict-shaped value (connection
+    config and similar structures are the realistic leak vector); scalars
+    and lists pass through unchanged. This is the single enforcement point
+    for redaction -- call sites pass raw config via ``extra`` and do not
+    need to remember to redact it themselves.
+    """
+    if isinstance(value, dict):
+        return redact_secrets(value)
+    return value
+
+
+class TextFormatter(logging.Formatter):
+    """Passthrough formatter: byte-compatible with today's print()/echo() output."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        text = record.getMessage()
+        if record.exc_info:
+            exc_text = self.formatException(record.exc_info)
+            text = f"{text}\n{exc_text}" if text else exc_text
+        return text
+
+
+class JSONFormatter(logging.Formatter):
+    """Flat JSONL formatter.
+
+    ``ts``/``level``/``msg`` are always present. If the call site passed
+    ``type`` via ``extra={}`` it is one of the six documented lifecycle
+    events and the rest of ``extra`` is included flat (no nested envelope).
+    Any other ``logger.*`` call still renders as valid JSON, just without a
+    ``type`` -- the schema is only documented/stable for the six named
+    events (see docs/development/logging.md).
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        ts = datetime.fromtimestamp(record.created, tz=UTC).isoformat(timespec="milliseconds")
+        ts = ts.replace("+00:00", "Z")
+
+        payload: dict[str, Any] = {
+            "ts": ts,
+            "level": record.levelname.lower(),
+        }
+
+        extra = _extra_fields(record)
+        event_type = extra.pop("type", None)
+        run_id = extra.pop("run_id", None)
+        if event_type is not None:
+            payload["type"] = event_type
+        if run_id is not None:
+            payload["run_id"] = run_id
+
+        payload["msg"] = record.getMessage()
+
+        for key, value in extra.items():
+            payload[key] = _redact(value)
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+
+        return json.dumps(payload, default=str)
+
+
+#: name -> Formatter class registry, keyed by ``--log-format``/``T4T_LOG_FORMAT``.
+#: A dict lookup (not an if/elif chain) so adding a future format (e.g. a
+#: dbt-compatible one, deliberately deferred -- see issue #36 non-goals) is a
+#: one-line addition here, not a rework of the call sites.
+FORMATTERS: dict[str, type[logging.Formatter]] = {
+    "text": TextFormatter,
+    "json": JSONFormatter,
+}
+
+#: Marker attribute used to find and replace a handler this module
+#: previously installed on the root logger, so repeated CLI invocations in
+#: the same process (e.g. the test suite) don't stack duplicate handlers.
+_HANDLER_MARKER = "_t4t_cli_output_handler"
+
+
+class _DynamicStdoutHandler(logging.StreamHandler):
+    """A StreamHandler that re-reads ``sys.stdout`` on every emit.
+
+    Plain ``logging.StreamHandler(stream=sys.stdout)`` binds whatever
+    ``sys.stdout`` object happens to exist at handler-construction time --
+    it does not notice later reassignment. That is a mismatch with how
+    ``print()``/``typer.echo()`` (and pytest's own stdout capture) behave:
+    they resolve ``sys.stdout`` fresh on every call, so e.g.
+    ``unittest.mock.patch("sys.stdout", new=StringIO())`` transparently
+    redirects them. Re-reading it here keeps that same behavior for the
+    logging-based replacement.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.stream = sys.stdout
+        super().emit(record)
+
+
+class _CliOutputFilter(logging.Filter):
+    """Only pass records eligible for t4t's curated stdout output stream.
+
+    Records from :data:`CLI_OUTPUT_LOGGER_NAMES` pass unconditionally (every
+    message in those modules used to be an unconditional print()/echo()).
+    Records from :data:`GATED_LOGGER_NAMES` only pass if they carry a
+    ``type`` (one of the six named lifecycle events) or ``cli_output=True``
+    (a mechanically-swapped former print()/echo() call site) marker -- those
+    modules also have other, pre-existing logging that was never on stdout
+    before this issue and must stay that way.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.name in CLI_OUTPUT_LOGGER_NAMES:
+            return True
+        if record.name in GATED_LOGGER_NAMES:
+            extra = _extra_fields(record)
+            return "type" in extra or extra.get("cli_output") is True
+        return False
+
+
+def resolve_log_format(value: str | None) -> str:
+    """Normalize a requested format, falling back to the default for unknown values."""
+    if value is None:
+        return DEFAULT_LOG_FORMAT
+    normalized = value.strip().lower()
+    return normalized if normalized in FORMATTERS else DEFAULT_LOG_FORMAT
+
+
+def configure_logging(log_format: str = DEFAULT_LOG_FORMAT, verbose: bool = False) -> None:
+    """Install the single stdout handler that renders t4t's run/build/test output.
+
+    Safe to call multiple times (e.g. once per CLI command invocation, or
+    repeatedly across a test session) -- a previous handler installed by
+    this function is removed first so records are never emitted twice.
+
+    This does not touch any other handler already attached to the root
+    logger (e.g. anything a host application configured); it only adds/
+    replaces the one handler this module owns.
+    """
+    formatter_cls = FORMATTERS.get(resolve_log_format(log_format), TextFormatter)
+
+    root_logger = logging.getLogger()
+
+    for existing in list(root_logger.handlers):
+        if getattr(existing, _HANDLER_MARKER, False):
+            root_logger.removeHandler(existing)
+
+    handler = _DynamicStdoutHandler(stream=sys.stdout)
+    handler.setFormatter(formatter_cls())
+    handler.addFilter(_CliOutputFilter())
+    handler.setLevel(logging.DEBUG if verbose else logging.INFO)
+    setattr(handler, _HANDLER_MARKER, True)
+
+    root_logger.addHandler(handler)
+    # The root logger's own level must not gate the allowlisted loggers'
+    # records before they even reach the handler above; each allowlisted
+    # logger is set explicitly so verbosity is controlled by the handler,
+    # not by having to raise the root logger's level (which would also
+    # raise the effective level of every other logger in the hierarchy).
+    for name in CLI_OUTPUT_LOGGER_NAMES | GATED_LOGGER_NAMES:
+        logging.getLogger(name).setLevel(logging.DEBUG if verbose else logging.INFO)

--- a/t4t/parser/output/json_exporter.py
+++ b/t4t/parser/output/json_exporter.py
@@ -71,8 +71,8 @@ class JSONExporter:
             with open(output_file, "w", encoding="utf-8") as f:
                 json.dump(parsed_models, f, indent=2, ensure_ascii=False)
 
-            print(f"Parsed models saved to {output_file}")
-            print(f"Found {len(parsed_models)} models")
+            logger.info(f"Parsed models saved to {output_file}", extra={"cli_output": True})
+            logger.info(f"Found {len(parsed_models)} models", extra={"cli_output": True})
 
             return output_file
 
@@ -111,9 +111,12 @@ class JSONExporter:
             logger.debug(f"Found {len(graph['nodes'])} tables")
             logger.debug(f"Execution order: {' -> '.join(graph['execution_order'])}")
             if graph["cycles"]:
-                print(f"Warning: Found {len(graph['cycles'])} circular dependencies!")
+                logger.warning(
+                    f"Warning: Found {len(graph['cycles'])} circular dependencies!",
+                    extra={"cli_output": True},
+                )
                 for cycle in graph["cycles"]:
-                    print(f"  Cycle: {' -> '.join(cycle)}")
+                    logger.warning(f"  Cycle: {' -> '.join(cycle)}", extra={"cli_output": True})
 
             return output_file
 

--- a/t4t/parser/output/report_generator.py
+++ b/t4t/parser/output/report_generator.py
@@ -119,9 +119,11 @@ Open `output/docs/index.html` (or your `--output-dir`) in a browser.
             with open(output_file, "w", encoding="utf-8") as f:
                 f.write(markdown_content)
 
-            logger.info(f"Markdown report saved to {output_file}")
-            print(f"Markdown report saved to {output_file}")
-            print("Includes detailed analysis (use `t4t docs` for interactive graph)")
+            logger.info(f"Markdown report saved to {output_file}", extra={"cli_output": True})
+            logger.info(
+                "Includes detailed analysis (use `t4t docs` for interactive graph)",
+                extra={"cli_output": True},
+            )
 
             return output_file
 

--- a/t4t/state/manifest.py
+++ b/t4t/state/manifest.py
@@ -123,8 +123,20 @@ def results_to_manifest(
     function_names: set[str] | None = None,
     environment: str | None = None,
     protected: bool = False,
+    run_id: str | None = None,
 ) -> RunManifest:
-    """Normalize execute_models or build_models result dicts into a RunManifest."""
+    """Normalize execute_models or build_models result dicts into a RunManifest.
+
+    Args:
+        run_id: Identity of the run, generated at the start of the CLI
+            command (`run.py`/`build.py`) and threaded through so the same
+            id correlates the JSON event stream with the persisted manifest.
+            Falls back to a freshly generated uuid if not provided, for
+            direct/programmatic callers that don't care about correlation
+            (e.g. existing unit tests) -- production call sites always pass
+            one explicitly and this function no longer mints the run's
+            "real" id itself.
+    """
     analysis = results.get("analysis") or {}
     execution_order: list[str] = list(analysis.get("execution_order") or [])
     graph = analysis.get("dependency_graph") or {}
@@ -226,7 +238,7 @@ def results_to_manifest(
     return RunManifest(
         schema_version=SCHEMA_VERSION,
         t4t_version=_t4t_version(),
-        run_id=str(uuid.uuid4()),
+        run_id=run_id or str(uuid.uuid4()),
         command=command,
         started_at=started_at,
         finished_at=finished_at,

--- a/t4t/testing/executor.py
+++ b/t4t/testing/executor.py
@@ -21,22 +21,31 @@ class TestExecutor:
 
     __test__ = False  # Tell pytest this is not a test class
 
-    def __init__(self, adapter: DatabaseAdapter, project_folder: str | None = None):
+    def __init__(
+        self,
+        adapter: DatabaseAdapter,
+        project_folder: str | None = None,
+        run_id: str | None = None,
+    ):
         """
         Initialize test executor.
 
         Args:
             adapter: Database adapter for executing test queries
             project_folder: Optional project folder path for discovering SQL tests
+            run_id: Identity of the run this test execution belongs to,
+                threaded into the model/function test executors so
+                test_started/test_finished events carry it.
         """
         self.adapter = adapter
         self.project_folder = Path(project_folder) if project_folder else None
         self.logger = logging.getLogger(self.__class__.__name__)
+        self.run_id = run_id
         self._test_discovery: TestDiscovery | None = None
 
         # Initialize executors
-        self.function_executor = FunctionTestExecutor(adapter)
-        self.model_executor = ModelTestExecutor(adapter, parsed_models=None)
+        self.function_executor = FunctionTestExecutor(adapter, run_id=run_id)
+        self.model_executor = ModelTestExecutor(adapter, parsed_models=None, run_id=run_id)
 
         # Discover and register SQL tests from tests/ folder
         if self.project_folder:

--- a/t4t/testing/executor.py
+++ b/t4t/testing/executor.py
@@ -39,7 +39,7 @@ class TestExecutor:
         """
         self.adapter = adapter
         self.project_folder = Path(project_folder) if project_folder else None
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__)
         self.run_id = run_id
         self._test_discovery: TestDiscovery | None = None
 

--- a/t4t/testing/executors/function_test_executor.py
+++ b/t4t/testing/executors/function_test_executor.py
@@ -6,6 +6,7 @@ Handles execution of tests for user-defined functions.
 
 import inspect
 import logging
+import time
 from typing import Any
 
 from t4t.adapters.base import DatabaseAdapter
@@ -19,15 +20,19 @@ logger = logging.getLogger(__name__)
 class FunctionTestExecutor:
     """Executes tests for user-defined functions."""
 
-    def __init__(self, adapter: DatabaseAdapter):
+    def __init__(self, adapter: DatabaseAdapter, run_id: str | None = None):
         """
         Initialize function test executor.
 
         Args:
             adapter: Database adapter for executing test queries
+            run_id: Identity of the run this test execution belongs to,
+                stamped on the test_started/test_finished events emitted
+                from `execute_tests_for_function` below.
         """
         self.adapter = adapter
         self.logger = logger
+        self.run_id = run_id
         self._used_test_names: set[str] = set()
 
     def execute_tests_for_function(
@@ -53,17 +58,45 @@ class FunctionTestExecutor:
             return results
 
         severity_overrides = severity_overrides or {}
+        test_defs = metadata.get("tests") or []
+        if not test_defs:
+            return results
 
-        # Execute function-level tests
-        if "tests" in metadata and metadata["tests"]:
-            for test_def in metadata["tests"]:
-                result = self._execute_single_function_test(
-                    function_name=function_name,
-                    test_def=test_def,
-                    severity_overrides=severity_overrides,
-                )
-                if result:
-                    results.append(result)
+        self.logger.info(
+            f"  🧪 {function_name}",
+            extra={
+                "type": "test_started",
+                "run_id": self.run_id,
+                "function": function_name,
+            },
+        )
+        start_time = time.monotonic()
+
+        for test_def in test_defs:
+            result = self._execute_single_function_test(
+                function_name=function_name,
+                test_def=test_def,
+                severity_overrides=severity_overrides,
+            )
+            if result:
+                results.append(result)
+
+        duration_ms = int((time.monotonic() - start_time) * 1000)
+        passed = sum(1 for r in results if r.passed)
+        failed = sum(1 for r in results if not r.passed and r.severity == TestSeverity.ERROR)
+        self.logger.info(
+            f"  🧪 {function_name}: {passed} passed, {failed} failed ({duration_ms / 1000:.1f}s)",
+            extra={
+                "type": "test_finished",
+                "run_id": self.run_id,
+                "function": function_name,
+                "status": "failed" if failed else "success",
+                "duration_ms": duration_ms,
+                "total": len(results),
+                "passed": passed,
+                "failed": failed,
+            },
+        )
 
         return results
 

--- a/t4t/testing/executors/model_test_executor.py
+++ b/t4t/testing/executors/model_test_executor.py
@@ -5,6 +5,7 @@ Handles execution of tests for models (tables/views).
 """
 
 import logging
+import time
 from typing import Any
 
 from t4t.adapters.base import DatabaseAdapter
@@ -23,6 +24,7 @@ class ModelTestExecutor:
         self,
         adapter: DatabaseAdapter,
         parsed_models: dict[str, Any] | None = None,
+        run_id: str | None = None,
     ):
         """
         Initialize model test executor.
@@ -31,10 +33,16 @@ class ModelTestExecutor:
             adapter: Database adapter for executing test queries
             parsed_models: Optional full parsed-models map so default-test injection can use
                 the same auto-built dimension registry as the parser/docs.
+            run_id: Identity of the run this test execution belongs to,
+                stamped on the test_started/test_finished events emitted
+                from `execute_tests_for_model` below. This is the common
+                hook point for both `t4t test` (via the batch test executor)
+                and `t4t build` (interleaved, per model).
         """
         self.adapter = adapter
         self.parsed_models = parsed_models
         self.logger = logger
+        self.run_id = run_id
         self._used_test_names: set[str] = set()
 
     def execute_tests_for_model(
@@ -66,6 +74,12 @@ class ModelTestExecutor:
         severity_overrides = severity_overrides or {}
 
         models_for_injection = parsed_models if parsed_models is not None else self.parsed_models
+
+        self.logger.info(
+            f"  🧪 {table_name}",
+            extra={"type": "test_started", "run_id": self.run_id, "model": table_name},
+        )
+        start_time = time.monotonic()
 
         # Inject default semantic tests (if enabled) and return WARNING results for any injection warnings.
         metadata_copy, warnings = inject_default_tests(
@@ -99,6 +113,23 @@ class ModelTestExecutor:
             results.extend(
                 self._execute_model_level_tests(table_name, metadata["tests"], severity_overrides)
             )
+
+        duration_ms = int((time.monotonic() - start_time) * 1000)
+        passed = sum(1 for r in results if r.passed)
+        failed = sum(1 for r in results if not r.passed and r.severity == TestSeverity.ERROR)
+        self.logger.info(
+            f"  🧪 {table_name}: {passed} passed, {failed} failed ({duration_ms / 1000:.1f}s)",
+            extra={
+                "type": "test_finished",
+                "run_id": self.run_id,
+                "model": table_name,
+                "status": "failed" if failed else "success",
+                "duration_ms": duration_ms,
+                "total": len(results),
+                "passed": passed,
+                "failed": failed,
+            },
+        )
 
         return results
 

--- a/tests/cli/commands/test_build.py
+++ b/tests/cli/commands/test_build.py
@@ -105,17 +105,23 @@ class TestBuildCommand:
         assert "All 2 tables executed successfully!" in output
         assert "All 4 tests passed!" in output
 
-        # Verify build_models was called correctly
-        mock_build_models.assert_called_once_with(
-            project_folder=str(mock_ctx.project_path),
-            connection_config=mock_config["connection"],
-            save_analysis=True,
-            variables={},
-            select_patterns=None,
-            exclude_patterns=None,
-            project_config=mock_ctx.config,
-            env_name="dev",
-        )
+        # Verify build_models was called correctly. run_id is generated
+        # fresh per invocation (see cmd_build) so only its presence/type is
+        # checked, not an exact value.
+        mock_build_models.assert_called_once()
+        call_kwargs = mock_build_models.call_args.kwargs
+        run_id = call_kwargs.pop("run_id", None)
+        assert isinstance(run_id, str) and run_id
+        assert call_kwargs == {
+            "project_folder": str(mock_ctx.project_path),
+            "connection_config": mock_config["connection"],
+            "save_analysis": True,
+            "variables": {},
+            "select_patterns": None,
+            "exclude_patterns": None,
+            "project_config": mock_ctx.config,
+            "env_name": "dev",
+        }
 
     @patch("t4t.cli.commands.build.build_models")
     @patch("t4t.cli.commands.build.ConnectionManager")

--- a/tests/cli/commands/test_run.py
+++ b/tests/cli/commands/test_run.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from click.exceptions import Exit as ClickExit
 
 from t4t.cli.commands.run import cmd_run
 
@@ -312,6 +313,44 @@ class TestRunCommand:
 
         # Verify error was handled
         mock_ctx.handle_error.assert_called_once()
+
+    @patch("t4t.cli.commands.run.execute_models")
+    @patch("t4t.cli.commands.run.ConnectionManager")
+    @patch("t4t.cli.commands.run.CommandContext")
+    def test_cmd_run_handles_keyboard_interrupt(
+        self, mock_context_class, mock_connection_manager_class, mock_execute_models, mock_args
+    ):
+        """Test that KeyboardInterrupt is handled gracefully -- same pattern
+        as t4t/cli/commands/build.py's test_build_handles_keyboard_interrupt,
+        run.py now catches KeyboardInterrupt explicitly to match build.py."""
+        # Setup mocks
+        mock_ctx = Mock()
+        mock_ctx.project_path = Path(mock_args.project_folder)
+        mock_ctx.vars = {}
+        mock_ctx.config = {"connection": {"type": "duckdb", "path": ":memory:"}}
+        mock_ctx.print_variables_info = Mock()
+        mock_ctx.print_selection_info = Mock()
+        mock_context_class.return_value = mock_ctx
+
+        mock_connection_manager = Mock()
+        mock_connection_manager_class.return_value = mock_connection_manager
+
+        # Mock KeyboardInterrupt
+        mock_execute_models.side_effect = KeyboardInterrupt()
+
+        # Capture stdout
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            try:
+                cmd_run(mock_args)
+            except (SystemExit, ClickExit) as e:
+                # Should exit with 130 for KeyboardInterrupt
+                # typer.Exit raises click.exceptions.Exit which is a SystemExit subclass
+                # click.exceptions.Exit uses .exit_code attribute
+                exit_code = getattr(e, "exit_code", getattr(e, "code", 0))
+                assert exit_code == 130, f"Expected exit code 130, got {exit_code}"
+
+        output = fake_out.getvalue()
+        assert "Run interrupted by user" in output
 
     @patch("t4t.cli.commands.run.execute_models")
     @patch("t4t.cli.commands.run.ConnectionManager")

--- a/tests/cli/commands/test_run.py
+++ b/tests/cli/commands/test_run.py
@@ -82,17 +82,23 @@ class TestRunCommand:
         assert "Completed!" in output
         assert "All 2 tables executed successfully!" in output
 
-        # Verify execute_models was called correctly
-        mock_execute_models.assert_called_once_with(
-            project_folder=str(mock_ctx.project_path),
-            connection_config=mock_ctx.config["connection"],
-            save_analysis=True,
-            variables={},
-            select_patterns=None,
-            exclude_patterns=None,
-            project_config=mock_ctx.config,
-            env_name="dev",
-        )
+        # Verify execute_models was called correctly. run_id is generated
+        # fresh per invocation (see cmd_run) so only its presence/type is
+        # checked, not an exact value.
+        mock_execute_models.assert_called_once()
+        call_kwargs = mock_execute_models.call_args.kwargs
+        run_id = call_kwargs.pop("run_id", None)
+        assert isinstance(run_id, str) and run_id
+        assert call_kwargs == {
+            "project_folder": str(mock_ctx.project_path),
+            "connection_config": mock_ctx.config["connection"],
+            "save_analysis": True,
+            "variables": {},
+            "select_patterns": None,
+            "exclude_patterns": None,
+            "project_config": mock_ctx.config,
+            "env_name": "dev",
+        }
 
     @patch("t4t.cli.commands.run.execute_models")
     @patch("t4t.cli.commands.run.ConnectionManager")

--- a/tests/cli/test_logging_e2e.py
+++ b/tests/cli/test_logging_e2e.py
@@ -17,6 +17,7 @@ run.py/build.py/test.py argument wiring.
 """
 
 import json
+import re
 import sqlite3
 import subprocess
 import sys
@@ -209,6 +210,90 @@ class TestRedaction:
         redacted = [line for line in lines if "connection_config" in line]
         assert redacted, "expected the connection_config diagnostic line to be present"
         assert redacted[0]["connection_config"]["password"] == "****"
+
+
+#: t4t/cli/utils.py:setup_logging()'s logging.basicConfig(format=...) --
+#: the pre-existing (predates this issue) stderr handler's exact line shape.
+_LEGACY_STDERR_LINE_RE = re.compile(r"^[A-Z]+ - ([\w.]+) - (.*)$", re.DOTALL)
+
+
+def _parse_legacy_stderr_lines(stderr: str) -> list[tuple[str, str]]:
+    """Return (logger_name, msg) for every stderr line matching the
+    pre-existing basicConfig "LEVEL - name - msg" format."""
+    parsed = []
+    for line in stderr.splitlines():
+        m = _LEGACY_STDERR_LINE_RE.match(line)
+        if m:
+            parsed.append((m.group(1), m.group(2)))
+    return parsed
+
+
+class TestStderrNotDuplicated:
+    """Regression test: t4t/cli/utils.py's pre-existing
+    `logging.basicConfig()` handler (predates this issue, still installed by
+    `CommandContext.__init__` via `setup_logging()`) must not *also* print
+    t4t's curated stdout content a second time, formatted as
+    "LEVEL - logger.name - msg" on stderr.
+
+    Deliberately scoped to *t4t's own curated loggers* re-appearing on
+    stderr (the actual failure mode this guards against: our new handler's
+    records leaking through the old one too), not "any text that looks
+    similar between the two streams" -- unrelated code paths coincidentally
+    using similar wording (e.g. `t4t/engine/executor.py`'s separate
+    "ModelExecutor"-named logger, which pre-dates this issue and has always
+    logged its own "Successfully executed tables:" independently of
+    `t4t/executor.py`'s curated one) is not a regression this issue caused
+    and must not fail this test.
+    """
+
+    def test_cli_output_logger_names_never_appear_on_stderr(self, project: Path):
+        """CLI_OUTPUT_LOGGER_NAMES loggers (t4t.executor, t4t.cli.commands.*)
+        are detached from root (propagate=False) precisely so their curated
+        content can never reach the legacy stderr handler -- verify none of
+        their names show up there at all."""
+        from t4t.observability.logging_setup import CLI_OUTPUT_LOGGER_NAMES
+
+        result = _run_t4t(["run", str(project)])
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        legacy_names = {name for name, _ in _parse_legacy_stderr_lines(result.stderr)}
+        leaked = legacy_names & CLI_OUTPUT_LOGGER_NAMES
+        assert not leaked, f"curated logger(s) leaked onto stderr: {leaked!r}"
+
+    def test_gated_logger_curated_messages_do_not_duplicate_onto_stderr(self, project: Path):
+        """GATED_LOGGER_NAMES loggers keep propagating to root (they mix
+        curated + genuine diagnostic content on one logger name), so the fix
+        for them is an exclusion filter on the legacy handler instead --
+        verify their *curated* (cli_output/type-marked) messages don't slip
+        through it and duplicate what our own handler already printed to
+        stdout."""
+        from t4t.observability.logging_setup import GATED_LOGGER_NAMES
+
+        result = _run_t4t(["run", str(project)])
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        stdout_lines = {line.strip() for line in result.stdout.splitlines() if line.strip()}
+        gated_on_stderr = [
+            (name, msg)
+            for name, msg in _parse_legacy_stderr_lines(result.stderr)
+            if name in GATED_LOGGER_NAMES
+        ]
+        duplicates = [(name, msg) for name, msg in gated_on_stderr if msg.strip() in stdout_lines]
+        assert not duplicates, (
+            f"gated logger curated content duplicated onto stderr: {duplicates!r}"
+        )
+
+    def test_stderr_line_count_is_stable_across_runs(self, project: Path):
+        """Cheap sanity check alongside the content-based tests above: two
+        runs against the same fixture produce the same stderr line count --
+        catches accidental handler stacking (e.g. a handler attached twice
+        across repeated `configure_logging()` calls in one process)."""
+        r1 = _run_t4t(["run", str(project)])
+        assert r1.returncode == 0, r1.stdout + r1.stderr
+        (project / "data" / "e2e.duckdb").unlink(missing_ok=True)
+        r2 = _run_t4t(["run", str(project)])
+        assert r2.returncode == 0, r2.stdout + r2.stderr
+        assert len(r1.stderr.splitlines()) == len(r2.stderr.splitlines())
 
 
 class TestTextModeNoDebugLeak:

--- a/tests/cli/test_logging_e2e.py
+++ b/tests/cli/test_logging_e2e.py
@@ -189,6 +189,75 @@ class TestSixNamedLifecycleEvents:
         assert types_in_order[-1] == "run_finished"
 
 
+class TestRunFinishedReliability:
+    """run_finished must fire even when the invocation crashes before
+    reaching a normal-completion branch -- run.py/build.py/test.py all use
+    a run_finished_emitted flag + `finally` block for exactly this.
+
+    Uses a project with an unsupported adapter `type` in project.toml: this
+    reliably raises deep inside each command's real work (ExecutionEngine
+    construction failing while executing/connecting), well after
+    run_started has already fired and well before any normal-completion
+    branch -- the actual early-crash path this guards against. (Deliberately
+    not "CommandContext construction fails", which happens *before*
+    run_started is ever emitted on any command -- no run_finished is
+    expected there either, on any command, since no run meaningfully
+    started; that's not the gap this test targets.)
+    """
+
+    def _write_project_with_unsupported_adapter(self, root: Path) -> Path:
+        (root / "models" / "t").mkdir(parents=True)
+        (root / "data").mkdir(parents=True)
+        db_path = root / "data" / "crash.duckdb"
+        (root / "project.toml").write_text(
+            f"""project_folder = "crash"
+[environments.dev.connection]
+type = "nonexistent_adapter_xyz"
+path = "{db_path.as_posix()}"
+""",
+            encoding="utf-8",
+        )
+        (root / "models" / "t" / "a.sql").write_text("SELECT 1 AS id\n", encoding="utf-8")
+        return root.resolve()
+
+    def _assert_single_run_finished_with_error(self, result: subprocess.CompletedProcess) -> None:
+        assert result.returncode != 0
+
+        lines = _json_lines(result.stdout)
+        typed = [line for line in lines if "type" in line]
+        types_in_order = [line["type"] for line in typed]
+
+        assert types_in_order[0] == "run_started"
+        assert types_in_order[-1] == "run_finished"
+        assert types_in_order.count("run_finished") == 1
+
+        run_finished = next(line for line in typed if line["type"] == "run_finished")
+        assert run_finished["status"] == "error"
+        run_started = next(line for line in typed if line["type"] == "run_started")
+        assert run_finished["run_id"] == run_started["run_id"]
+
+    def test_test_command_early_crash_still_emits_run_finished(self, tmp_path: Path):
+        """The gap this was filed for: t4t/cli/commands/test.py did not
+        have the run_finished_emitted + finally pattern before this fix."""
+        project = self._write_project_with_unsupported_adapter(tmp_path / "crash_proj_test")
+        result = _run_t4t(["test", str(project), "--log-format", "json"])
+        self._assert_single_run_finished_with_error(result)
+
+    def test_run_command_early_crash_still_emits_run_finished(self, tmp_path: Path):
+        """Same crash path via `t4t run` -- covers run.py's identical
+        run_finished_emitted + finally pattern."""
+        project = self._write_project_with_unsupported_adapter(tmp_path / "crash_proj_run")
+        result = _run_t4t(["run", str(project), "--log-format", "json"])
+        self._assert_single_run_finished_with_error(result)
+
+    def test_build_command_early_crash_still_emits_run_finished(self, tmp_path: Path):
+        """Same crash path via `t4t build` -- covers build.py's identical
+        run_finished_emitted + finally pattern."""
+        project = self._write_project_with_unsupported_adapter(tmp_path / "crash_proj_build")
+        result = _run_t4t(["build", str(project), "--log-format", "json"])
+        self._assert_single_run_finished_with_error(result)
+
+
 class TestRedaction:
     """Design decision 5: a fake secret in connection config must never
     appear in captured JSON log output -- proven, not assumed."""
@@ -212,8 +281,9 @@ class TestRedaction:
         assert redacted[0]["connection_config"]["password"] == "****"
 
 
-#: t4t/cli/utils.py:setup_logging()'s logging.basicConfig(format=...) --
-#: the pre-existing (predates this issue) stderr handler's exact line shape.
+#: t4t.observability.logging_setup._install_legacy_root_handler()'s
+#: logging.basicConfig(format=...) -- the pre-existing (predates this issue)
+#: stderr handler's exact line shape.
 _LEGACY_STDERR_LINE_RE = re.compile(r"^[A-Z]+ - ([\w.]+) - (.*)$", re.DOTALL)
 
 
@@ -229,10 +299,11 @@ def _parse_legacy_stderr_lines(stderr: str) -> list[tuple[str, str]]:
 
 
 class TestStderrNotDuplicated:
-    """Regression test: t4t/cli/utils.py's pre-existing
-    `logging.basicConfig()` handler (predates this issue, still installed by
-    `CommandContext.__init__` via `setup_logging()`) must not *also* print
-    t4t's curated stdout content a second time, formatted as
+    """Regression test: the pre-existing `logging.basicConfig()` handler
+    (predates this issue; installed by `configure_logging()` itself, as its
+    own first step via `_install_legacy_root_handler()`, so there is no
+    cross-function call-order dependency for a caller to get wrong) must not
+    *also* print t4t's curated stdout content a second time, formatted as
     "LEVEL - logger.name - msg" on stderr.
 
     Deliberately scoped to *t4t's own curated loggers* re-appearing on

--- a/tests/cli/test_logging_e2e.py
+++ b/tests/cli/test_logging_e2e.py
@@ -1,0 +1,249 @@
+"""
+Subprocess-level acceptance tests for GitHub issue #36 (structured logging).
+
+These run `t4t` as a *real* subprocess (`python -m t4t.cli.main ...`), not
+via Typer's in-process CliRunner or a mocked CommandContext -- per the
+issue's acceptance criteria, several of these need a real subprocess run:
+
+- run_id must match between the JSON event stream and runs.sqlite for the
+  same invocation.
+- `t4t run --log-format json | jq` must succeed: every stdout line valid JSON.
+- A fake secret in connection config must never appear in captured JSON
+  output.
+
+See tests/observability/test_logging_setup.py for formatter/filter unit
+tests, and tests/cli/commands/ for the existing (updated) unit tests of
+run.py/build.py/test.py argument wiring.
+"""
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _write_minimal_project(root: Path, *, extra_toml: str = "") -> Path:
+    """A tiny 2-model duckdb project: t.b depends on t.a, plus one singular
+    SQL test on t.a so `t4t build`/`t4t test` have something to run
+    (test_started/test_finished only fire when a model has test metadata)."""
+    (root / "models" / "t").mkdir(parents=True)
+    (root / "data").mkdir(parents=True)
+    (root / "tests").mkdir(parents=True)
+
+    db_path = root / "data" / "e2e.duckdb"
+    (root / "project.toml").write_text(
+        f"""project_folder = "e2e"
+[environments.dev.connection]
+type = "duckdb"
+path = "{db_path.as_posix()}"
+{extra_toml}
+""",
+        encoding="utf-8",
+    )
+    (root / "models" / "t" / "a.sql").write_text("SELECT 1 AS id, 'x' AS name\n", encoding="utf-8")
+    (root / "models" / "t" / "b.sql").write_text("SELECT * FROM a\n", encoding="utf-8")
+    # Companion metadata file attaching a built-in generic test to t.a, the
+    # same pattern as examples/t_project/models/my_schema/my_first_table.py
+    # -- a bare .sql file has no metadata block of its own. `schema` must be
+    # present (even empty) for MetadataExtractor.extract_model_metadata to
+    # recognize this as real metadata -- see
+    # t4t/engine/metadata/metadata_extractor.py.
+    (root / "models" / "t" / "a.py").write_text(
+        "from t4t.parser.processing.model_builder import SqlModelMetadata\n"
+        "from t4t.typing.metadata import ModelMetadata\n\n"
+        'metadata: ModelMetadata = {"schema": [], "tests": ["row_count_gt_0"]}\n'
+        "model = SqlModelMetadata(metadata)\n",
+        encoding="utf-8",
+    )
+    return root.resolve()
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    return _write_minimal_project(tmp_path / "proj")
+
+
+def _run_t4t(args: list[str], **env_overrides: str) -> subprocess.CompletedProcess:
+    import os
+
+    env = os.environ.copy()
+    env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, "-m", "t4t.cli.main", *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=env,
+        timeout=120,
+    )
+
+
+def _json_lines(stdout: str) -> list[dict]:
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    parsed = []
+    for i, line in enumerate(lines, 1):
+        try:
+            parsed.append(json.loads(line))
+        except json.JSONDecodeError as e:  # pragma: no cover - assertion helper
+            pytest.fail(f"stdout line {i} is not valid JSON: {line!r} ({e})")
+    return parsed
+
+
+class TestJSONModeIsValidJSONL:
+    """Acceptance criterion: `t4t run --log-format json | jq` succeeds --
+    every stdout line is valid JSON."""
+
+    def test_every_stdout_line_is_valid_json(self, project: Path):
+        result = _run_t4t(["run", str(project), "--log-format", "json"])
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        lines = _json_lines(result.stdout)
+        assert len(lines) > 0
+        for payload in lines:
+            assert "ts" in payload
+            assert "level" in payload
+            assert "msg" in payload
+
+    def test_t4t_log_format_env_var_also_selects_json(self, project: Path):
+        result = _run_t4t(["run", str(project)], T4T_LOG_FORMAT="json")
+        assert result.returncode == 0, result.stdout + result.stderr
+        lines = _json_lines(result.stdout)
+        assert len(lines) > 0
+
+
+class TestRunIdJoin:
+    """Acceptance criterion: the same run_id appears in every JSON event and
+    in runs.sqlite for that invocation -- verified at the CLI level."""
+
+    def test_run_id_matches_json_stream_and_runs_sqlite(self, project: Path):
+        result = _run_t4t(["run", str(project), "--log-format", "json"])
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        lines = _json_lines(result.stdout)
+        run_started = [line for line in lines if line.get("type") == "run_started"]
+        assert len(run_started) == 1
+        run_id = run_started[0]["run_id"]
+        assert isinstance(run_id, str) and run_id
+
+        # Every event that carries a run_id must carry the *same* one.
+        event_run_ids = {line["run_id"] for line in lines if "run_id" in line}
+        assert event_run_ids == {run_id}
+
+        runs_sqlite = project / "output" / "dev" / "runs.sqlite"
+        assert runs_sqlite.is_file()
+        conn = sqlite3.connect(runs_sqlite)
+        try:
+            row = conn.execute("select run_id from runs order by rowid desc limit 1").fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row[0] == run_id
+
+
+class TestSixNamedLifecycleEvents:
+    """Design decision 2: exactly the 6 named events, run_started first,
+    run_finished last, same run_id throughout."""
+
+    def test_run_emits_run_started_model_events_and_run_finished_in_order(self, project: Path):
+        result = _run_t4t(["run", str(project), "--log-format", "json"])
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        lines = _json_lines(result.stdout)
+        typed = [line for line in lines if "type" in line]
+        types_in_order = [line["type"] for line in typed]
+
+        assert types_in_order[0] == "run_started"
+        assert types_in_order[-1] == "run_finished"
+        assert set(types_in_order) <= {
+            "run_started",
+            "model_started",
+            "model_finished",
+            "test_started",
+            "test_finished",
+            "run_finished",
+        }
+        # Two models (t.a, t.b) -> one started/finished pair each.
+        assert types_in_order.count("model_started") == 2
+        assert types_in_order.count("model_finished") == 2
+        # Every model_started is immediately paired with its model_finished
+        # before the next model_started (real per-model timing, not a batch
+        # bookend at the end).
+        for i, t in enumerate(types_in_order):
+            if t == "model_started":
+                assert types_in_order[i + 1] == "model_finished"
+
+    def test_build_also_emits_test_lifecycle_events(self, project: Path):
+        result = _run_t4t(["build", str(project), "--log-format", "json"])
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        types_in_order = [line["type"] for line in _json_lines(result.stdout) if "type" in line]
+        assert "test_started" in types_in_order
+        assert "test_finished" in types_in_order
+        assert types_in_order[0] == "run_started"
+        assert types_in_order[-1] == "run_finished"
+
+
+class TestRedaction:
+    """Design decision 5: a fake secret in connection config must never
+    appear in captured JSON log output -- proven, not assumed."""
+
+    def test_fake_secret_never_appears_in_json_output(self, tmp_path: Path):
+        secret = "sk-FAKE-SECRET-e2e-99887766"
+        proj = _write_minimal_project(tmp_path / "proj", extra_toml=f'password = "{secret}"\n')
+
+        # --verbose so the debug-level "Resolved connection configuration"
+        # diagnostic (which carries the *unredacted* config via extra, by
+        # design -- the formatter is responsible for redacting it) fires.
+        result = _run_t4t(["run", str(proj), "--log-format", "json", "--verbose"])
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        assert secret not in result.stdout
+        assert secret not in result.stderr
+
+        lines = _json_lines(result.stdout)
+        redacted = [line for line in lines if "connection_config" in line]
+        assert redacted, "expected the connection_config diagnostic line to be present"
+        assert redacted[0]["connection_config"]["password"] == "****"
+
+
+class TestTextModeNoDebugLeak:
+    """Constraint 2 / acceptance criterion: no previously-silent
+    logger.debug call sites become newly visible in text mode by default."""
+
+    def test_default_text_mode_has_no_internal_debug_chatter(self, project: Path):
+        result = _run_t4t(["run", str(project)])
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        # These are real, pre-existing logger.debug/info call sites in
+        # engine/adapter modules (not part of t4t's curated CLI output) that
+        # must stay off stdout by default -- see
+        # t4t.observability.logging_setup.GATED_LOGGER_NAMES /
+        # CLI_OUTPUT_LOGGER_NAMES.
+        never_on_stdout_by_default = [
+            "Starting execution of",  # t4t.engine.executors.model_executor
+            "Starting project compilation",  # t4t.compiler
+            "Connected to DuckDB database",  # adapter internals
+            "Executing model:",  # model_executor debug line
+        ]
+        for needle in never_on_stdout_by_default:
+            assert needle not in result.stdout, f"{needle!r} leaked into default text stdout"
+
+        # ...but the genuinely new, intentional per-model progress lines
+        # (this issue's whole point) are there.
+        assert "▶ t.a" in result.stdout
+        assert "✅ t.a" in result.stdout
+        assert "Running t4t on project:" in result.stdout
+        assert "Completed!" in result.stdout
+
+    def test_verbose_text_mode_does_not_crash_and_still_only_curated_output(self, project: Path):
+        """--verbose enables debug level for t4t's own curated loggers, but
+        must not turn on unrelated internal chatter on stdout (still gated
+        by the allowlist/marker, not just level)."""
+        result = _run_t4t(["run", str(project), "--verbose"])
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Starting execution of" not in result.stdout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,25 @@ import pytest
 
 from t4t.adapters.duckdb.adapter import DuckDBAdapter
 from t4t.engine.model_state import ModelStateManager
+from t4t.observability import configure_logging
+
+
+@pytest.fixture(autouse=True)
+def _configure_t4t_logging():
+    """Wire up t4t's stdout logging handler for every test.
+
+    Mirrors what `CommandContext.__init__` does for a real CLI invocation.
+    Tests that call `cmd_run`/`cmd_build`/`cmd_test` directly typically mock
+    `CommandContext` itself (to avoid real config loading), which means the
+    real handler-install side effect never runs -- this fixture ensures a
+    handler is always present, in default text mode, so `print()`-like
+    assertions against captured stdout keep working. Tests that want JSON
+    mode or verbose call `configure_logging(...)` again themselves; each
+    call safely replaces the previously-installed handler (see
+    `t4t.observability.logging_setup.configure_logging`).
+    """
+    configure_logging("text", verbose=False)
+    yield
 
 
 @pytest.fixture

--- a/tests/observability/test_logging_setup.py
+++ b/tests/observability/test_logging_setup.py
@@ -9,14 +9,20 @@ against a real invocation, and JSONL well-formedness for `t4t run`).
 
 import json
 import logging
+from io import StringIO
+from unittest.mock import patch
 
 import pytest
 
 from t4t.observability.logging_setup import (
+    _HANDLER_MARKER,
     FORMATTERS,
     JSONFormatter,
     TextFormatter,
     _CliOutputFilter,
+    _DynamicStdoutHandler,
+    _ExcludeCuratedFilter,
+    configure_logging,
     resolve_log_format,
 )
 
@@ -161,6 +167,41 @@ class TestFormatterRegistry:
         assert resolve_log_format("dbt-json") == "text"
         assert resolve_log_format(None) == "text"
 
+    def test_resolve_log_format_strict_raises_for_unknown(self):
+        """strict=True is what t4t/cli/main.py:validate_log_format() uses to
+        reject bad --log-format input outright -- see
+        TestValidateLogFormat below for the CLI-callback-level test."""
+        with pytest.raises(ValueError, match="Invalid log format"):
+            resolve_log_format("dbt-json", strict=True)
+
+    @pytest.mark.parametrize("value", ["text", "TEXT", " Text ", "json", " json"])
+    def test_resolve_log_format_strict_accepts_known_values(self, value):
+        assert resolve_log_format(value, strict=True) == value.strip().lower()
+
+
+class TestValidateLogFormat:
+    """t4t.cli.main.validate_log_format() -- the --log-format Typer
+    callback -- must delegate entirely to resolve_log_format(strict=True)
+    rather than reimplementing its own, slightly different normalization.
+    Regression coverage for the specific drift this replaced: the old
+    callback only lowercased (no whitespace stripping), so a stray-whitespace
+    value like " json" would pass resolve_log_format() but be rejected here,
+    inconsistently."""
+
+    @pytest.mark.parametrize("value", ["text", "TEXT", " json ", "JSON"])
+    def test_accepts_and_normalizes_known_values(self, value):
+        from t4t.cli.main import validate_log_format
+
+        assert validate_log_format(value) == value.strip().lower()
+
+    def test_rejects_unknown_value_with_bad_parameter(self):
+        import typer
+
+        from t4t.cli.main import validate_log_format
+
+        with pytest.raises(typer.BadParameter):
+            validate_log_format("dbt-json")
+
 
 class TestCliOutputFilter:
     def test_unconditional_logger_always_passes(self):
@@ -195,3 +236,127 @@ class TestCliOutputFilter:
             name="t4t.adapters.duckdb.adapter", msg="Connected to DuckDB database: x"
         )
         assert _CliOutputFilter().filter(record) is False
+
+
+class TestConfigureLoggingInstallsLegacyHandlerItself:
+    """Structural regression test for the ordering footgun this module used
+    to have: ``configure_logging()`` must install the legacy
+    ``basicConfig``-based root handler itself (via
+    ``_install_legacy_root_handler``, as its own first step), rather than
+    depending on some *other* function (the old, separate
+    ``t4t/cli/utils.py:setup_logging()`` call site) having run first. That
+    used to be an implicit, unenforced ordering dependency between two call
+    sites in ``CommandContext.__init__``; ``CommandContext`` now calls only
+    ``configure_logging()``. This test proves the property structurally --
+    by calling ``configure_logging()`` completely alone, with no prior
+    logging setup of any kind -- rather than merely by convention/comment.
+    """
+
+    #: The exact ``basicConfig(format=...)`` string
+    #: ``_install_legacy_root_handler`` uses -- distinguishes the legacy
+    #: handler from pytest's own root-logger ``LogCaptureHandler``.
+    _LEGACY_FMT = "%(levelname)s - %(name)s - %(message)s"
+
+    @pytest.fixture(autouse=True)
+    def _isolated_root_logger(self):
+        """Save/restore the real root logger's handlers and level around
+        each test, and start each test with a *clean* root logger (no
+        handlers at all -- including pytest's own log-capture handler,
+        which pytest re-attaches for the call phase after fixture setup
+        runs, so it must be cleared inside the test body, not just here).
+
+        This mirrors the real-world scenario the underlying bug is about: a
+        fresh process where nothing has called ``logging.basicConfig()``
+        yet, so ``configure_logging()`` alone is responsible for installing
+        the legacy handler.
+        """
+        root = logging.getLogger()
+        saved_handlers = list(root.handlers)
+        saved_level = root.level
+        yield root
+        root.handlers = saved_handlers
+        root.setLevel(saved_level)
+
+    def _legacy_handlers(self, root: logging.Logger) -> list[logging.Handler]:
+        return [
+            h
+            for h in root.handlers
+            if not getattr(h, _HANDLER_MARKER, False)
+            and getattr(h.formatter, "_fmt", None) == self._LEGACY_FMT
+        ]
+
+    def test_configure_logging_alone_installs_a_legacy_handler_with_exclude_filter(
+        self, _isolated_root_logger
+    ):
+        """With *zero* prior logging setup (no separate basicConfig call
+        from anywhere else -- e.g. the old, now-removed
+        ``t4t/cli/utils.py:setup_logging()`` call site), configure_logging()
+        alone must still end up with a legacy handler on root carrying an
+        _ExcludeCuratedFilter -- proving the legacy handler is installed
+        unconditionally as part of configure_logging() itself, not
+        contingent on a separate, order-dependent caller running first."""
+        root = _isolated_root_logger
+        # Clear here, not only in the fixture: pytest's logging plugin
+        # re-attaches its own capture handler for the call phase after
+        # fixture setup runs, so this must happen right before the call
+        # under test to reproduce a truly handler-free root logger.
+        root.handlers = []
+        assert self._legacy_handlers(root) == []
+
+        configure_logging(log_format="text", verbose=False)
+
+        legacy_handlers = self._legacy_handlers(root)
+        assert legacy_handlers, "configure_logging() must install a legacy root handler itself"
+        assert any(
+            any(isinstance(f, _ExcludeCuratedFilter) for f in h.filters) for h in legacy_handlers
+        ), "the legacy handler must carry the exclusion filter"
+
+    def test_configure_logging_is_idempotent_across_repeated_calls(self, _isolated_root_logger):
+        """Calling configure_logging() repeatedly (e.g. multiple CLI
+        commands in one process, or a test session) must not keep stacking
+        legacy handlers -- logging.basicConfig() is a no-op once a root
+        handler already exists, so exactly one legacy handler should remain
+        no matter how many times configure_logging() runs."""
+        root = _isolated_root_logger
+        root.handlers = []
+
+        configure_logging(log_format="text", verbose=False)
+        configure_logging(log_format="json", verbose=True)
+        configure_logging(log_format="text", verbose=False)
+
+        assert len(self._legacy_handlers(root)) == 1
+
+
+class TestDynamicStdoutHandlerStdoutNone:
+    """sys.stdout can legitimately be None (pythonw.exe, or any environment
+    that detaches/closes standard streams) -- _DynamicStdoutHandler.emit()
+    re-reads sys.stdout on every call (needed for test-mocking, e.g.
+    unittest.mock.patch("sys.stdout", new=StringIO())), so it must guard
+    against that rather than handing None to StreamHandler.emit()."""
+
+    def _make_record(self, msg: str = "hello") -> logging.LogRecord:
+        return logging.getLogger("test.dynamic_stdout").makeRecord(
+            "test.dynamic_stdout", logging.INFO, "test_file.py", 1, msg, (), None
+        )
+
+    def test_falls_back_to_stderr_when_stdout_is_none(self):
+        handler = _DynamicStdoutHandler()
+        fake_stderr = StringIO()
+        with (
+            patch("sys.stdout", None),
+            patch("sys.stderr", fake_stderr),
+        ):
+            handler.emit(self._make_record("hello"))
+        assert "hello" in fake_stderr.getvalue()
+
+    def test_does_not_raise_when_both_stdout_and_stderr_are_none(self):
+        handler = _DynamicStdoutHandler()
+        with patch("sys.stdout", None), patch("sys.stderr", None):
+            handler.emit(self._make_record("hello"))  # must not raise
+
+    def test_still_writes_to_stdout_normally_when_present(self):
+        handler = _DynamicStdoutHandler()
+        fake_stdout = StringIO()
+        with patch("sys.stdout", fake_stdout):
+            handler.emit(self._make_record("hello"))
+        assert "hello" in fake_stdout.getvalue()

--- a/tests/observability/test_logging_setup.py
+++ b/tests/observability/test_logging_setup.py
@@ -1,0 +1,197 @@
+"""
+Unit tests for t4t.observability.logging_setup: TextFormatter, JSONFormatter,
+the format registry, and the stdout eligibility filter.
+
+See tests/cli/test_logging_e2e.py for subprocess-level acceptance tests
+(run_id join across the JSON stream and runs.sqlite, the redaction test
+against a real invocation, and JSONL well-formedness for `t4t run`).
+"""
+
+import json
+import logging
+
+import pytest
+
+from t4t.observability.logging_setup import (
+    FORMATTERS,
+    JSONFormatter,
+    TextFormatter,
+    _CliOutputFilter,
+    resolve_log_format,
+)
+
+_LOGGER = logging.getLogger("test.observability")
+
+
+def _make_record(
+    level: int = logging.INFO,
+    msg: str = "hello",
+    extra: dict | None = None,
+    name: str = "test.observability",
+) -> logging.LogRecord:
+    """Build a real LogRecord the way stdlib logging would, extra and all."""
+    return _LOGGER.makeRecord(name, level, "test_file.py", 1, msg, (), None, extra=extra)
+
+
+class TestTextFormatter:
+    def test_passthrough_message(self):
+        record = _make_record(msg="Running t4t on project: demo")
+        assert TextFormatter().format(record) == "Running t4t on project: demo"
+
+    def test_ignores_extra_fields(self):
+        """Text mode must be byte-compatible with the old print()/echo() content --
+        structured fields passed via extra must never leak into the text line."""
+        record = _make_record(
+            msg="  ✅ my_schema.t (0.8s, 12,043 rows)",
+            extra={
+                "type": "model_finished",
+                "run_id": "abc-123",
+                "model": "my_schema.t",
+                "status": "success",
+                "duration_ms": 800,
+                "row_count": 12043,
+            },
+        )
+        assert TextFormatter().format(record) == "  ✅ my_schema.t (0.8s, 12,043 rows)"
+
+    def test_percent_style_args_are_interpolated(self):
+        record = _make_record(msg="")
+        record = _LOGGER.makeRecord(
+            "test.observability",
+            logging.WARNING,
+            "f.py",
+            1,
+            "Could not persist: %s",
+            ("boom",),
+            None,
+        )
+        assert TextFormatter().format(record) == "Could not persist: boom"
+
+
+class TestJSONFormatter:
+    def test_always_has_ts_level_msg(self):
+        record = _make_record(msg="Refreshing generated lookup models...")
+        payload = json.loads(JSONFormatter().format(record))
+        assert {"ts", "level", "msg"} <= payload.keys()
+        assert payload["level"] == "info"
+        assert payload["msg"] == "Refreshing generated lookup models..."
+        assert "type" not in payload
+        assert "run_id" not in payload
+
+    def test_ts_is_iso8601_utc_with_milliseconds(self):
+        record = _make_record(msg="x")
+        payload = json.loads(JSONFormatter().format(record))
+        # e.g. "2026-07-23T09:14:02.113Z"
+        assert payload["ts"].endswith("Z")
+        assert "T" in payload["ts"]
+        assert "." in payload["ts"]
+
+    def test_named_lifecycle_event_carries_type_run_id_and_flat_fields(self):
+        record = _make_record(
+            msg="  ✅ my_schema.t (0.8s, 12,043 rows)",
+            extra={
+                "type": "model_finished",
+                "run_id": "3f2a1e4c-0000-0000-0000-000000000000",
+                "model": "my_schema.t",
+                "status": "success",
+                "duration_ms": 800,
+                "row_count": 12043,
+                "materialization": "table",
+            },
+        )
+        payload = json.loads(JSONFormatter().format(record))
+        assert payload["type"] == "model_finished"
+        assert payload["run_id"] == "3f2a1e4c-0000-0000-0000-000000000000"
+        # Flat -- no nested "data" envelope (Terraform-style, not dbt-style).
+        assert payload["model"] == "my_schema.t"
+        assert payload["status"] == "success"
+        assert payload["duration_ms"] == 800
+        assert payload["row_count"] == 12043
+        assert payload["materialization"] == "table"
+        assert "data" not in payload
+
+    def test_generic_message_has_no_type_field_but_is_still_valid_json(self):
+        record = _make_record(msg="Refreshing generated lookup models...")
+        line = JSONFormatter().format(record)
+        payload = json.loads(line)  # must not raise
+        assert "type" not in payload
+
+    def test_redacts_dict_valued_extra_field(self):
+        """The formatter -- not the call site -- is responsible for redaction."""
+        record = _make_record(
+            msg="Resolved connection configuration",
+            extra={
+                "connection_config": {
+                    "type": "postgresql",
+                    "password": "sk-super-secret-value",
+                    "host": "db.example.com",
+                }
+            },
+        )
+        line = JSONFormatter().format(record)
+        assert "sk-super-secret-value" not in line
+        payload = json.loads(line)
+        assert payload["connection_config"]["password"] == "****"
+        assert payload["connection_config"]["host"] == "db.example.com"
+
+    def test_redaction_does_not_affect_non_secret_keys(self):
+        record = _make_record(
+            msg="x",
+            extra={"connection_config": {"type": "duckdb", "path": "data/x.duckdb"}},
+        )
+        payload = json.loads(JSONFormatter().format(record))
+        assert payload["connection_config"] == {"type": "duckdb", "path": "data/x.duckdb"}
+
+
+class TestFormatterRegistry:
+    def test_registry_has_exactly_text_and_json(self):
+        assert set(FORMATTERS.keys()) == {"text", "json"}
+        assert FORMATTERS["text"] is TextFormatter
+        assert FORMATTERS["json"] is JSONFormatter
+
+    @pytest.mark.parametrize("value", ["text", "TEXT", " Text "])
+    def test_resolve_log_format_text(self, value):
+        assert resolve_log_format(value) == "text"
+
+    @pytest.mark.parametrize("value", ["json", "JSON"])
+    def test_resolve_log_format_json(self, value):
+        assert resolve_log_format(value) == "json"
+
+    def test_resolve_log_format_falls_back_to_default_for_unknown(self):
+        assert resolve_log_format("dbt-json") == "text"
+        assert resolve_log_format(None) == "text"
+
+
+class TestCliOutputFilter:
+    def test_unconditional_logger_always_passes(self):
+        record = _make_record(name="t4t.cli.commands.run", msg="Running t4t on project: x")
+        assert _CliOutputFilter().filter(record) is True
+
+    def test_gated_logger_blocked_without_marker(self):
+        """A pre-existing, non-lifecycle logger.debug/info call in a gated
+        module (e.g. compiler.py's "Starting project compilation...") must
+        NOT reach stdout -- it never did before this issue."""
+        record = _make_record(
+            name="t4t.compiler", msg="Starting project compilation to OTS modules"
+        )
+        assert _CliOutputFilter().filter(record) is False
+
+    def test_gated_logger_passes_with_cli_output_marker(self):
+        record = _make_record(
+            name="t4t.compiler", msg="✅ No conflicts detected", extra={"cli_output": True}
+        )
+        assert _CliOutputFilter().filter(record) is True
+
+    def test_gated_logger_passes_with_lifecycle_type_marker(self):
+        record = _make_record(
+            name="t4t.engine.executors.model_executor",
+            msg="  ▶ my_schema.t",
+            extra={"type": "model_started", "run_id": "x", "model": "my_schema.t"},
+        )
+        assert _CliOutputFilter().filter(record) is True
+
+    def test_unrelated_logger_always_blocked(self):
+        record = _make_record(
+            name="t4t.adapters.duckdb.adapter", msg="Connected to DuckDB database: x"
+        )
+        assert _CliOutputFilter().filter(record) is False


### PR DESCRIPTION
## Summary

Closes #36.

Replaces `t4t`'s raw `print()`/`typer.echo()` output (in `t4t/executor.py` and the `run`/`build`/`test` CLI command files) with Python's stdlib `logging`, and adds a real `--log-format text|json` (default `text`) / `T4T_LOG_FORMAT` env var. Text mode is byte-compatible with today's output plus new, genuinely live per-model/per-test progress lines. JSON mode emits clean JSONL to stdout, with six named, schema-documented lifecycle events (`run_started`, `model_started`, `model_finished`, `test_started`, `test_finished`, `run_finished`) sharing one `run_id` per invocation, joinable against `runs.sqlite`.

- `t4t/observability/logging_setup.py`: `TextFormatter`/`JSONFormatter` behind a `dict[str, type[Formatter]]` registry (not an if/elif chain), one stdout handler installed at CLI startup. `JSONFormatter` applies `redact_secrets()` centrally so call sites never redact for themselves.
- `run_id` generation moved to the very start of `run.py`/`build.py`/`test.py` and threaded through `execute_models()`/`build_models()` → `ModelExecutor` → `ExecutionEngine` → the real per-model executor, and into the run manifest (which no longer mints its own uuid).
- Real per-model timing + `model_started`/`model_finished` added to `ModelExecutor.execute()`'s loop (`t4t/engine/executors/model_executor.py`) — the one place with a live per-model hook, used by both `run` (whole batch) and `build` (per-model calls, same underlying pathway). `test_started`/`test_finished` added at `ModelTestExecutor.execute_tests_for_model` / `FunctionTestExecutor.execute_tests_for_function`, the common hook for both `t4t test` and `t4t build`.
- New `CLAUDE.md` at repo root (hard rule: use logging, never raw print/echo beyond argument-validation errors), `docs/development/contributing.md` Code Style section, `docs/development/code-review.md` danger-zones bullet, and `docs/development/logging.md` (the JSON schema doc).

### Scope note / judgment call

The issue's audit named `t4t/executor.py` + the 3 CLI command files (~110 call sites) as the swap scope. Empirically running `t4t run --log-format json | jq` against a real fixture project surfaced that `t4t/compiler.py`, `t4t/parser/output/json_exporter.py`, and `t4t/parser/output/report_generator.py` also `print()` during every `run`/`build`/`test` invocation (via `compile_project()`) — required for "every stdout line is valid JSON" to actually hold, so I extended the swap to those files too (gated behind an explicit `cli_output`/lifecycle marker, since they also carry pre-existing, unrelated `logger.debug`/`info` calls that must stay off stdout by default). Also extended to `t4t/executor_helpers/build_helpers.py` for the same reason on the `t4t build` path. Documented in the second commit's message.

Other judgment calls:
- The issue's usage example shows `run_started`'s `msg` as `"Running t4t on project: myproject (env: prod)"` (with an env suffix); I kept the existing message text unchanged (`"Running t4t on project: {project_folder}"`, no suffix) and only added the `type`/`run_id`/etc. fields via `extra={}`, prioritizing the "text output identical to today" acceptance criterion over the drafted example's literal wording.
- `run_started`/`run_finished` piggyback on the existing first/last message rather than adding new lines, to keep the "only new content is per-model progress" diff clean; on hard crash paths (before the "Completed!" line is reached) a fallback `run_finished` (`status: "error"`) is emitted as a new line in `run.py`/`build.py`'s `finally` block — the one place new content appears outside the per-model/test progress lines, and only on an exceptional path.
- `test_started`/`test_finished` fire per-model (not per-individual-test), mirroring `model_started`/`model_finished`'s grain, to keep the JSON stream proportionate.

## Test plan

- [x] `t4t run --log-format json | jq` succeeds; every stdout line valid JSON — `tests/cli/test_logging_e2e.py::TestJSONModeIsValidJSONL`
- [x] Same `run_id` in every JSON event and in `runs.sqlite`, verified via a real subprocess (not just unit-tested) — `TestRunIdJoin::test_run_id_matches_json_stream_and_runs_sqlite`
- [x] Text-mode output unchanged for pre-existing messages, plus new per-model progress lines — verified empirically by diffing a real `t4t run` before/after on `examples/t_project` (24 new lines, all `▶`/`✅` per-model progress, zero other diffs); standing regression coverage in `TestTextModeNoDebugLeak`
- [x] No previously-silent `logger.debug` call sites become newly visible in text mode by default — same empirical diff, plus `TestTextModeNoDebugLeak::test_default_text_mode_has_no_internal_debug_chatter`
- [x] Fake secret in connection config never appears in captured JSON output — `TestRedaction::test_fake_secret_never_appears_in_json_output` (subprocess-level, `--verbose --log-format json`)
- [x] `CLAUDE.md` exists with the logging rule; `contributing.md` and `code-review.md` updated to match
- [x] Six named lifecycle events, `run_started` first / `run_finished` last, `model_started` immediately paired with `model_finished` — `TestSixNamedLifecycleEvents`
- [x] Formatter/filter unit tests (`tests/observability/test_logging_setup.py`, 21 tests) plus full existing suite green: `uv run pytest tests/ -m "not snowflake_e2e"` → 1479 passed (2 failed / 30 errors are pre-existing `snowflake-connector-python` env issues on `main`, unrelated to this PR — confirmed against a clean `origin/main` checkout)
- [x] `uv run ruff check t4t tests` / `uv run ruff format --check t4t tests` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)