### PR TITLE
Pluggable warehouse state backend

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -126,6 +126,28 @@ schema_prefix = "dev_"
 
 This prefixes the schema portion of all object names (e.g. `my_schema.my_table` → `dev_my_schema.my_table`). The primary environment separation mechanism is per-env connections (different `database`/`path` per environment).
 
+### State backend (local vs warehouse)
+
+```toml
+[environments.prod.state]
+backend = "warehouse"   # or "local" (default) -- omit the section entirely for "local"
+```
+
+`backend` controls where t4t persists run manifests and model
+[fingerprints](../user-guide/fingerprinting.md):
+
+- **`"local"`** (default, and what you get if you omit `[environments.<env>.state]`
+  entirely) -- unchanged from before this option existed: `output/<env>/last_run.json`
+  and `output/<env>/runs.sqlite` on local disk.
+- **`"warehouse"`** -- state is stored in the environment's own connection
+  instead, using no separate credentials. A fresh CI container has no local
+  disk history at all, so this is what makes `--retry` and `definition:changed`
+  selection work correctly across ephemeral runners and team members sharing
+  one warehouse, not just on a single developer's machine.
+
+See [State backends](../user-guide/state-backends.md) for the on-disk/in-warehouse
+layout, per-adapter ordering-column mechanism, and the BigQuery caveat.
+
 ## `pyproject.toml` (Python-package projects)
 
 If your t4t project lives inside a Python package that already has a `pyproject.toml`, you can put t4t config under `[tool.t4t]`:

--- a/docs/user-guide/fingerprinting.md
+++ b/docs/user-guide/fingerprinting.md
@@ -64,13 +64,21 @@ unchanged model with different `--vars` values produces the same
 
 ## Where fingerprints are stored
 
-Fingerprints are persisted through the same `StateBackend` used for run
-manifests (`t4t/state/backend.py`), scoped per environment the same way:
-`output/<env>/runs.sqlite`, in a `fingerprints` table alongside the existing
-`runs` table. After each run, t4t writes `sql_hash`/`config_hash`/
-`fingerprint` for every model that was *attempted* (selected and execution
-was attempted) that run, regardless of whether that particular model's
-execution succeeded or failed.
+Fingerprints are persisted through the same pluggable `StateBackend` used
+for run manifests (`t4t/state/backend.py`), scoped per environment. Where
+that actually is depends on `environments.<env>.state.backend` (see
+[State backends](state-backends.md)):
+
+- **`"local"`** (default) -- `output/<env>/runs.sqlite`, in a
+  `fingerprints` table alongside the existing `runs` table.
+- **`"warehouse"`** -- the environment's own connection, in a
+  `<model's schema>_STATE.t4t_model_state` table alongside run-manifest
+  rows.
+
+After each run, t4t writes `sql_hash`/`config_hash`/`fingerprint` for every
+model that was *attempted* (selected and execution was attempted) that run,
+regardless of whether that particular model's execution succeeded or
+failed.
 
 Each stored record also carries a `fingerprint_spec_version`. If the
 algorithm or its inputs change in a future t4t release, that version is

--- a/docs/user-guide/state-backends.md
+++ b/docs/user-guide/state-backends.md
@@ -1,0 +1,159 @@
+# State Backends
+
+t4t persists two kinds of run state after every `t4t run`/`t4t build`:
+
+- **Run manifests** -- what happened in a run (which models succeeded,
+  failed, or were skipped), used by `--retry`.
+- **Model [fingerprints](fingerprinting.md)** -- a stable hash of each
+  model's definition, the foundation for future change-detection features
+  (`definition:changed` selection, `t4t plan`, Slim CI).
+
+Where that state lives is controlled per environment by
+`environments.<env>.state.backend`, and is fully pluggable behind a single
+`StateBackend` interface (`t4t/state/backend.py`). Two implementations exist
+today: `"local"` (the default) and `"warehouse"`.
+
+## `"local"` (default)
+
+```toml
+# No [environments.<env>.state] section needed -- this is the default.
+```
+
+State is written to local disk under the project's `output/` directory:
+`output/<env>/last_run.json` and `output/<env>/runs.sqlite`. This is simple
+and has no extra requirements, but it means state lives only on the machine
+that ran `t4t` -- a fresh CI container, or a teammate running `t4t` from
+their own machine, has no access to it. `--retry` and any future
+`definition:changed` selection have no baseline to work from in that case.
+
+## `"warehouse"`
+
+```toml
+[environments.prod.state]
+backend = "warehouse"
+```
+
+State is written to the environment's own connection instead -- the same
+`AdapterConfig`/connection the environment's models already use, no separate
+credentials or infrastructure. This is what makes state usable from any
+machine or CI runner that can connect to the warehouse, not just the one
+that produced it.
+
+### Layout: one state table per data schema
+
+For every *data* schema a run touches (e.g. `analytics`, `staging`), t4t
+auto-creates a paired `<schema>_STATE` schema containing a single shared
+table, `t4t_model_state`:
+
+```
+$ t4t run myproject --env prod
+Using state backend: warehouse
+  analytics.* -> analytics_STATE.t4t_model_state
+  staging.*   -> staging_STATE.t4t_model_state
+```
+
+`t4t_model_state` holds both run-manifest rows (one per run) and per-model
+fingerprint rows (one per model per run), distinguished by a `record_type`
+column (`'run'` or `'fingerprint'`) -- a `model_name` column distinguishes
+which model a fingerprint row belongs to, the same "one table, many models"
+shape `output/<env>/runs.sqlite`'s `fingerprints` table already uses
+locally, extended into a paired warehouse schema rather than redesigned.
+
+This is a **shared table per data schema**, not one state table per model
+table: a schema with 50 models still gets exactly one
+`<schema>_STATE.t4t_model_state`, not 50 separate state tables. Per-model
+state tables were considered and rejected -- they would multiply
+DDL/table-management cost forever for a benefit (per-table permissioning)
+nobody asked for; schema-level permission alignment already satisfies the
+actual goal of keeping state co-located with the data it describes.
+
+Schema and table creation use `CREATE SCHEMA IF NOT EXISTS`/`CREATE TABLE IF
+NOT EXISTS`, so this happens automatically on first use -- see
+[Missing permissions](#missing-permissions-create-schemacreate-table) below
+for what happens when the connection isn't allowed to create them.
+
+### Run ordering: a database-native sequence, not a timestamp
+
+Multiple CI runners or team members can write state concurrently, and clock
+skew across machines makes a wall-clock "latest run" subtly wrong under
+concurrent writes. To avoid that, "latest" is decided by a database-native
+identity/sequence column (`ORDER BY id DESC`), not a timestamp -- except on
+BigQuery, which has no such mechanism (see below). All writes are
+`INSERT`-only (never updated in place), matching the append-only shape
+`runs.sqlite` already uses locally.
+
+The exact mechanism differs per adapter, because DuckDB's support turned out
+to differ from the other two despite an initial assumption that all three
+worked the same way:
+
+| Adapter | Ordering mechanism |
+| --- | --- |
+| PostgreSQL | `id BIGINT GENERATED ALWAYS AS IDENTITY` |
+| Snowflake | `id NUMBER GENERATED ALWAYS AS IDENTITY` |
+| DuckDB | `CREATE SEQUENCE` + `id BIGINT DEFAULT nextval(...)` -- DuckDB does not support `GENERATED ALWAYS AS IDENTITY` (`Constraint not implemented`, confirmed directly against a real DuckDB connection) |
+| BigQuery | **No ordering column.** See below. |
+
+### BigQuery: known limitation, wall-clock ordering only
+
+BigQuery has no native identity or sequence mechanism at all. The warehouse
+backend falls back to a `written_at` timestamp column and orders by it
+(`ORDER BY written_at DESC`) -- last-write-wins, with the same clock-skew
+caveat under concurrent writers that the identity/sequence mechanism exists
+to avoid on the other three adapters. This is a deliberate, documented v1
+limitation, not something this feature attempts to solve further; revisit
+only if it becomes a real problem in practice for BigQuery users running
+concurrent/overlapping writers.
+
+### Missing permissions (`CREATE SCHEMA`/`CREATE TABLE`)
+
+Some warehouses run with locked-down service accounts that aren't granted
+DDL rights. If the connection can't create the `<schema>_STATE` schema or
+`t4t_model_state` table, t4t does **not** surface a raw permission-denied
+stack trace. Instead, the run fails with an error that includes the exact
+DDL an admin can run manually to grant a one-time head start, e.g.:
+
+```
+Could not create warehouse state schema/table for data schema 'analytics'
+(...): permission denied for schema analytics_STATE.
+
+Ask a database admin to run the following DDL manually, then re-run:
+
+CREATE SCHEMA IF NOT EXISTS analytics_STATE
+
+CREATE TABLE IF NOT EXISTS analytics_STATE.t4t_model_state (
+    ...
+)
+```
+
+If a run touches multiple data schemas and creation succeeds for some but
+fails for others, the **whole run fails** -- t4t does not proceed with
+state tracked for some models and not others. Partial state coverage is
+worse than no coverage at all: a future `definition:changed` selector would
+silently treat the untracked models as always-changed (or never-changed)
+without any indication something was missed.
+
+## Switching backends
+
+Switching `backend` between `"local"` and `"warehouse"` (in either
+direction) does **not** migrate any existing state. The first run under the
+new backend simply has no baseline: any feature that depends on a stored
+baseline (`--retry`, or a future `definition:changed` selector) fails open
+-- it warns and treats every model as if it had never been run/fingerprinted
+before, rather than crashing or misinterpreting the old backend's state.
+This matches how a `fingerprint_spec_version` mismatch is already handled:
+there's no way to convert one backend's state into the other's shape, so
+t4t doesn't attempt to.
+
+## What this does not cover
+
+- **S3/GCS/standalone-Postgres-as-a-separate-service backends** -- not
+  implemented. The warehouse backend is deliberately co-located with the
+  environment's own connection, not a separate storage service.
+- **Concurrent-writer stress testing.** The ordering-column mechanism is
+  verified with sequential writes producing correctly-ordered rows; genuine
+  concurrent-process races have not been tested. If a real race condition
+  is observed in practice, that's a follow-up, not something this design
+  assumes away.
+- **State for secondary/named connections** (`environments.<env>.connections.*`).
+  The warehouse backend tracks state only for models materialized via the
+  environment's *primary* connection.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
     - user-guide/data-quality-tests.md
     - user-guide/incremental-materialization.md
     - user-guide/fingerprinting.md
+    - user-guide/state-backends.md
     - user-guide/database-adapters.md
     - user-guide/tags-and-metadata.md
     - user-guide/sql-dialect-conversion.md

--- a/t4t/adapters/base/__init__.py
+++ b/t4t/adapters/base/__init__.py
@@ -8,7 +8,7 @@ All components are re-exported here for backward compatibility.
 # Import core components
 from .config import AdapterConfig, MaterializationType, NamingConfig, SecretProvider
 from .core import DatabaseAdapter
-from .state_table import StateTableDDLError
+from .state_table import SchemaEnsureError, StateTableDDLError
 
 # Re-export everything for backward compatibility
 # This allows: from ..base import DatabaseAdapter, AdapterConfig, MaterializationType
@@ -18,5 +18,6 @@ __all__ = [
     "MaterializationType",
     "NamingConfig",
     "SecretProvider",
+    "SchemaEnsureError",
     "StateTableDDLError",
 ]

--- a/t4t/adapters/base/__init__.py
+++ b/t4t/adapters/base/__init__.py
@@ -8,6 +8,7 @@ All components are re-exported here for backward compatibility.
 # Import core components
 from .config import AdapterConfig, MaterializationType, NamingConfig, SecretProvider
 from .core import DatabaseAdapter
+from .state_table import StateTableDDLError
 
 # Re-export everything for backward compatibility
 # This allows: from ..base import DatabaseAdapter, AdapterConfig, MaterializationType
@@ -17,4 +18,5 @@ __all__ = [
     "MaterializationType",
     "NamingConfig",
     "SecretProvider",
+    "StateTableDDLError",
 ]

--- a/t4t/adapters/base/core.py
+++ b/t4t/adapters/base/core.py
@@ -9,10 +9,11 @@ from typing import Any
 from .config import AdapterConfig, MaterializationType
 from .metadata import MetadataHandler
 from .sql import SQLProcessor
+from .state_table import StateTableMixin
 from .testing import TestQueryGenerator
 
 
-class DatabaseAdapter(ABC, SQLProcessor, MetadataHandler, TestQueryGenerator):
+class DatabaseAdapter(ABC, SQLProcessor, MetadataHandler, TestQueryGenerator, StateTableMixin):
     """
     Abstract base class for database adapters.
 

--- a/t4t/adapters/base/state_table.py
+++ b/t4t/adapters/base/state_table.py
@@ -47,6 +47,33 @@ class StateTableDDLError(Exception):
         )
 
 
+class SchemaEnsureError(Exception):
+    """Raised when the multi-schema pre-creation guard
+    (``WarehouseStateBackend.ensure_schemas_for_models``) fails for a reason
+    that is *not* a DDL/permission problem -- e.g. a transient connection
+    failure while opening the adapter, before any DDL was even attempted.
+
+    Per #20's design decision, "a run touching multiple data schemas fails
+    as a whole if any schema's DDL fails" is not narrowed to permission
+    failures only: any failure of the guard means we don't actually know
+    whether every touched schema's state table exists, so the run must
+    abort rather than continue with unknown/partial state coverage. This is
+    the sibling of ``StateTableDDLError`` for that non-DDL case -- callers
+    (see ``t4t/executor.py``'s ``_try_persist_run_manifest``) re-raise both
+    rather than swallowing either into a best-effort warning.
+    """
+
+    def __init__(self, original: Exception) -> None:
+        self.original = original
+        super().__init__(
+            "Could not pre-create the warehouse state schema(s) for this run "
+            f"({original.__class__.__name__}: {original}). This was not a "
+            "DDL/permission failure -- most likely a transient connection "
+            "problem. The run has been aborted rather than proceeding with "
+            "unknown/partial state coverage; please retry."
+        )
+
+
 class StateTableMixin:
     """Mixin providing the ``<schema>_STATE.t4t_model_state`` naming
     convention and DDL orchestration shared across adapters.

--- a/t4t/adapters/base/state_table.py
+++ b/t4t/adapters/base/state_table.py
@@ -1,0 +1,125 @@
+"""Shared scaffolding for the warehouse state table (#20).
+
+Each adapter that supports the ``warehouse`` state backend hand-writes its
+own DDL (schema/table creation, including the ordering-column mechanism --
+``GENERATED ALWAYS AS IDENTITY`` for PostgreSQL/Snowflake, ``CREATE
+SEQUENCE`` + ``DEFAULT nextval(...)`` for DuckDB, a ``written_at`` timestamp
+fallback for BigQuery) and its own parameterized insert/select methods,
+rather than routing this through sqlglot transpilation -- see #20's "DDL
+approach" design decision: a handful of fixed system columns, not user SQL.
+
+This module only holds what is genuinely shared: the ``<schema>_STATE``
+naming convention and the orchestration/error-wrapping around running the
+per-adapter DDL. See ``t4t/state/warehouse_backend.py`` for the
+``StateBackend`` Protocol implementation that calls into these adapter
+methods.
+"""
+
+from typing import Any
+
+STATE_TABLE_NAME = "t4t_model_state"
+
+
+class StateTableDDLError(Exception):
+    """Raised when creating the warehouse state schema/table fails.
+
+    Most commonly this means the connection lacks ``CREATE SCHEMA``/``CREATE
+    TABLE`` permission (common in locked-down/governed warehouses). Per #20's
+    design decision, this is deliberately *not* a raw permission-denied
+    stack trace: the exact DDL text is included so a database admin can run
+    it manually, and the whole run fails (see #20's multi-schema
+    partial-failure rule) rather than proceeding with partial state
+    coverage.
+    """
+
+    def __init__(self, data_schema: str, ddl_statements: list[str], original: Exception) -> None:
+        self.data_schema = data_schema
+        self.ddl_statements = list(ddl_statements)
+        self.original = original
+        ddl_text = "\n\n".join(self.ddl_statements)
+        super().__init__(
+            f"Could not create warehouse state schema/table for data schema "
+            f"'{data_schema}' ({original.__class__.__name__}: {original}).\n\n"
+            "This usually means the connection lacks CREATE SCHEMA/CREATE TABLE "
+            "permission. Ask a database admin to run the following DDL manually, "
+            "then re-run:\n\n"
+            f"{ddl_text}"
+        )
+
+
+class StateTableMixin:
+    """Mixin providing the ``<schema>_STATE.t4t_model_state`` naming
+    convention and DDL orchestration shared across adapters.
+
+    Concrete adapters implement:
+
+    - ``_state_table_ddl_statements(data_schema)``: the hand-written
+      ``CREATE SCHEMA``/``CREATE SEQUENCE``/``CREATE TABLE`` statements for
+      that database.
+    - ``_execute_state_ddl_statement(stmt)``: runs one DDL statement using
+      the adapter's raw connection (no dialect transpilation).
+    - ``insert_run_state``/``read_latest_run_state``/
+      ``insert_fingerprint_state``/``read_fingerprint_state``: parameterized
+      DML using the adapter's own driver, matching how other adapter methods
+      in this codebase already talk to their driver directly (see e.g.
+      ``SnowflakeAdapter._execute_with_cursor``).
+    """
+
+    STATE_TABLE_NAME = STATE_TABLE_NAME
+
+    def state_schema_name(self, data_schema: str) -> str:
+        """The paired state schema for a data schema, e.g. ``analytics`` ->
+        ``analytics_STATE``."""
+        return f"{data_schema}_STATE"
+
+    def state_table_ref(self, data_schema: str) -> str:
+        """Fully-qualified state table name for *data_schema*.
+
+        Overridden by ``BigQueryAdapter`` to include the ``project`` prefix
+        BigQuery requires.
+        """
+        return f"{self.state_schema_name(data_schema)}.{self.STATE_TABLE_NAME}"
+
+    def _state_table_ddl_statements(self, data_schema: str) -> list[str]:
+        raise NotImplementedError
+
+    def _execute_state_ddl_statement(self, stmt: str) -> None:
+        raise NotImplementedError
+
+    def ensure_state_table(self, data_schema: str) -> None:
+        """Create ``<data_schema>_STATE.t4t_model_state`` if it doesn't exist.
+
+        Raises ``StateTableDDLError`` (including the literal DDL text) if
+        any statement fails -- most commonly a missing ``CREATE SCHEMA``/
+        ``CREATE TABLE`` grant. Callers (see
+        ``WarehouseStateBackend._ensure_schemas``) let this propagate so the
+        whole run fails rather than proceeding with partial state coverage.
+        """
+        statements = self._state_table_ddl_statements(data_schema)
+        for stmt in statements:
+            try:
+                self._execute_state_ddl_statement(stmt)
+            except Exception as e:
+                raise StateTableDDLError(data_schema, statements, e) from e
+
+    # -- DML: implemented per adapter, stubs here document the shape only --
+
+    def insert_run_state(self, data_schema: str, run_id: str, manifest_json: str) -> None:
+        raise NotImplementedError
+
+    def read_latest_run_state(self, data_schema: str) -> str | None:
+        raise NotImplementedError
+
+    def insert_fingerprint_state(
+        self,
+        data_schema: str,
+        model_name: str,
+        sql_hash: str,
+        config_hash: str,
+        fingerprint: str,
+        fingerprint_spec_version: int,
+    ) -> None:
+        raise NotImplementedError
+
+    def read_fingerprint_state(self, data_schema: str, model_name: str) -> dict[str, Any] | None:
+        raise NotImplementedError

--- a/t4t/adapters/bigquery/adapter.py
+++ b/t4t/adapters/bigquery/adapter.py
@@ -435,6 +435,149 @@ class BigQueryAdapter(DatabaseAdapter):
 
             raise FunctionExecutionError(f"Failed to drop function {function_name}: {e}") from e
 
+    # -- Warehouse state table (#20) --------------------------------------
+    #
+    # BigQuery has no native identity/sequence mechanism at all (confirmed
+    # by #20's research -- no `GENERATED ALWAYS AS IDENTITY`, no
+    # `CREATE SEQUENCE`). V1 falls back to a wall-clock `written_at`
+    # timestamp for ordering, last-write-wins semantics -- a documented
+    # known limitation (see docs/user-guide), not something this issue
+    # attempts to solve further. Not independently tested here against a
+    # live BigQuery connection (none available in this environment).
+    #
+    # `CREATE SCHEMA` is BigQuery's supported alias for creating a dataset
+    # (`CREATE SCHEMA [IF NOT EXISTS] project.dataset`); table/dataset
+    # queries go through `self.client.query(...)` directly (like every
+    # other DDL method in this adapter) rather than `execute_query`, which
+    # runs `convert_sql_dialect`/`qualify_table_references` -- this is
+    # hand-written system SQL, not user SQL that needs dialect conversion.
+
+    def state_table_ref(self, data_schema: str) -> str:
+        return (
+            f"`{self.config.project}.{self.state_schema_name(data_schema)}.{self.STATE_TABLE_NAME}`"
+        )
+
+    def _state_schema_ref(self, data_schema: str) -> str:
+        return f"`{self.config.project}.{self.state_schema_name(data_schema)}`"
+
+    def _state_table_ddl_statements(self, data_schema: str) -> list[str]:
+        schema_ref = self._state_schema_ref(data_schema)
+        table = self.state_table_ref(data_schema)
+        return [
+            f"CREATE SCHEMA IF NOT EXISTS {schema_ref}",
+            f"""
+            CREATE TABLE IF NOT EXISTS {table} (
+                record_type STRING NOT NULL,
+                written_at TIMESTAMP NOT NULL,
+                run_id STRING,
+                manifest_json STRING,
+                model_name STRING,
+                sql_hash STRING,
+                config_hash STRING,
+                fingerprint STRING,
+                fingerprint_spec_version INT64
+            )
+            """.strip(),
+        ]
+
+    def _execute_state_ddl_statement(self, stmt: str) -> None:
+        if not self.client:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        query_job = self.client.query(stmt)
+        query_job.result()
+
+    def insert_run_state(self, data_schema: str, run_id: str, manifest_json: str) -> None:
+        if not self.client:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        from google.cloud import bigquery
+
+        table = self.state_table_ref(data_schema)
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ScalarQueryParameter("run_id", "STRING", run_id),
+                bigquery.ScalarQueryParameter("manifest_json", "STRING", manifest_json),
+            ]
+        )
+        query_job = self.client.query(
+            f"INSERT INTO {table} (record_type, written_at, run_id, manifest_json) "
+            "VALUES ('run', CURRENT_TIMESTAMP(), @run_id, @manifest_json)",
+            job_config=job_config,
+        )
+        query_job.result()
+
+    def read_latest_run_state(self, data_schema: str) -> str | None:
+        if not self.client:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        table = self.state_table_ref(data_schema)
+        query_job = self.client.query(
+            f"SELECT manifest_json FROM {table} "
+            "WHERE record_type = 'run' ORDER BY written_at DESC LIMIT 1"
+        )
+        rows = list(query_job.result())
+        return rows[0][0] if rows else None
+
+    def insert_fingerprint_state(
+        self,
+        data_schema: str,
+        model_name: str,
+        sql_hash: str,
+        config_hash: str,
+        fingerprint: str,
+        fingerprint_spec_version: int,
+    ) -> None:
+        if not self.client:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        from google.cloud import bigquery
+
+        table = self.state_table_ref(data_schema)
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ScalarQueryParameter("model_name", "STRING", model_name),
+                bigquery.ScalarQueryParameter("sql_hash", "STRING", sql_hash),
+                bigquery.ScalarQueryParameter("config_hash", "STRING", config_hash),
+                bigquery.ScalarQueryParameter("fingerprint", "STRING", fingerprint),
+                bigquery.ScalarQueryParameter(
+                    "fingerprint_spec_version", "INT64", fingerprint_spec_version
+                ),
+            ]
+        )
+        query_job = self.client.query(
+            f"INSERT INTO {table} "
+            "(record_type, written_at, model_name, sql_hash, config_hash, fingerprint, "
+            "fingerprint_spec_version) "
+            "VALUES ('fingerprint', CURRENT_TIMESTAMP(), @model_name, @sql_hash, @config_hash, "
+            "@fingerprint, @fingerprint_spec_version)",
+            job_config=job_config,
+        )
+        query_job.result()
+
+    def read_fingerprint_state(self, data_schema: str, model_name: str) -> dict[str, Any] | None:
+        if not self.client:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        from google.cloud import bigquery
+
+        table = self.state_table_ref(data_schema)
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[bigquery.ScalarQueryParameter("model_name", "STRING", model_name)]
+        )
+        query_job = self.client.query(
+            "SELECT sql_hash, config_hash, fingerprint, fingerprint_spec_version, written_at "
+            f"FROM {table} WHERE record_type = 'fingerprint' AND model_name = @model_name "
+            "ORDER BY written_at DESC LIMIT 1",
+            job_config=job_config,
+        )
+        rows = list(query_job.result())
+        if not rows:
+            return None
+        row = rows[0]
+        return {
+            "sql_hash": row[0],
+            "config_hash": row[1],
+            "fingerprint": row[2],
+            "fingerprint_spec_version": row[3],
+            "updated_at": str(row[4]) if row[4] is not None else None,
+        }
+
 
 # Register the adapter
 register_adapter("bigquery", BigQueryAdapter)

--- a/t4t/adapters/duckdb/adapter.py
+++ b/t4t/adapters/duckdb/adapter.py
@@ -459,6 +459,100 @@ class DuckDBAdapter(DatabaseAdapter):
             ) AS duplicate_groups
         """
 
+    # -- Warehouse state table (#20) --------------------------------------
+    #
+    # DuckDB does not support `GENERATED ALWAYS AS IDENTITY` (`Constraint not
+    # implemented`, confirmed empirically -- see #20's design decisions), so
+    # the ordering column uses `CREATE SEQUENCE` + a column `DEFAULT
+    # nextval(...)` instead, which DuckDB does support.
+
+    def _state_table_ddl_statements(self, data_schema: str) -> list[str]:
+        schema = self.state_schema_name(data_schema)
+        table = self.state_table_ref(data_schema)
+        seq = f"{schema}.{self.STATE_TABLE_NAME}_id_seq"
+        return [
+            f"CREATE SCHEMA IF NOT EXISTS {schema}",
+            f"CREATE SEQUENCE IF NOT EXISTS {seq}",
+            f"""
+            CREATE TABLE IF NOT EXISTS {table} (
+                id BIGINT PRIMARY KEY DEFAULT nextval('{seq}'),
+                record_type VARCHAR NOT NULL,
+                written_at TIMESTAMP NOT NULL,
+                run_id VARCHAR,
+                manifest_json VARCHAR,
+                model_name VARCHAR,
+                sql_hash VARCHAR,
+                config_hash VARCHAR,
+                fingerprint VARCHAR,
+                fingerprint_spec_version INTEGER
+            )
+            """.strip(),
+        ]
+
+    def _execute_state_ddl_statement(self, stmt: str) -> None:
+        if not self.connection:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        self.connection.execute(stmt)
+
+    def insert_run_state(self, data_schema: str, run_id: str, manifest_json: str) -> None:
+        if not self.connection:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        table = self.state_table_ref(data_schema)
+        self.connection.execute(
+            f"INSERT INTO {table} (record_type, written_at, run_id, manifest_json) "
+            "VALUES ('run', CURRENT_TIMESTAMP, ?, ?)",
+            [run_id, manifest_json],
+        )
+
+    def read_latest_run_state(self, data_schema: str) -> str | None:
+        if not self.connection:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        table = self.state_table_ref(data_schema)
+        row = self.connection.execute(
+            f"SELECT manifest_json FROM {table} WHERE record_type = 'run' ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        return row[0] if row else None
+
+    def insert_fingerprint_state(
+        self,
+        data_schema: str,
+        model_name: str,
+        sql_hash: str,
+        config_hash: str,
+        fingerprint: str,
+        fingerprint_spec_version: int,
+    ) -> None:
+        if not self.connection:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        table = self.state_table_ref(data_schema)
+        self.connection.execute(
+            f"INSERT INTO {table} "
+            "(record_type, written_at, model_name, sql_hash, config_hash, fingerprint, "
+            "fingerprint_spec_version) "
+            "VALUES ('fingerprint', CURRENT_TIMESTAMP, ?, ?, ?, ?, ?)",
+            [model_name, sql_hash, config_hash, fingerprint, fingerprint_spec_version],
+        )
+
+    def read_fingerprint_state(self, data_schema: str, model_name: str) -> dict[str, Any] | None:
+        if not self.connection:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        table = self.state_table_ref(data_schema)
+        row = self.connection.execute(
+            "SELECT sql_hash, config_hash, fingerprint, fingerprint_spec_version, written_at "
+            f"FROM {table} WHERE record_type = 'fingerprint' AND model_name = ? "
+            "ORDER BY id DESC LIMIT 1",
+            [model_name],
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            "sql_hash": row[0],
+            "config_hash": row[1],
+            "fingerprint": row[2],
+            "fingerprint_spec_version": row[3],
+            "updated_at": str(row[4]) if row[4] is not None else None,
+        }
+
     def _build_motherduck_connection_string(self, db_path: str) -> str:
         """
         Build MotherDuck connection string with authentication token.

--- a/t4t/adapters/postgresql/adapter.py
+++ b/t4t/adapters/postgresql/adapter.py
@@ -500,6 +500,137 @@ class PostgreSQLAdapter(DatabaseAdapter):
 
             raise FunctionExecutionError(f"Failed to drop function {function_name}: {e}") from e
 
+    # -- Warehouse state table (#20) --------------------------------------
+    #
+    # PostgreSQL supports the SQL-standard `GENERATED ALWAYS AS IDENTITY`
+    # column, used as the ordering column for `read_latest` (a
+    # database-native sequence, not a wall-clock timestamp -- #20's
+    # concurrency-ordering design decision). Not independently tested here
+    # against a live PostgreSQL connection (none available in this
+    # environment) -- this is well-established, documented PostgreSQL 10+
+    # syntax, but see #20's implementation report for the exact scope of
+    # what was/wasn't verified against a real connection.
+
+    def _state_table_ddl_statements(self, data_schema: str) -> list[str]:
+        schema = self.state_schema_name(data_schema)
+        table = self.state_table_ref(data_schema)
+        return [
+            f"CREATE SCHEMA IF NOT EXISTS {schema}",
+            f"""
+            CREATE TABLE IF NOT EXISTS {table} (
+                id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                record_type VARCHAR(20) NOT NULL,
+                written_at TIMESTAMPTZ NOT NULL,
+                run_id VARCHAR,
+                manifest_json TEXT,
+                model_name VARCHAR,
+                sql_hash VARCHAR,
+                config_hash VARCHAR,
+                fingerprint VARCHAR,
+                fingerprint_spec_version INTEGER
+            )
+            """.strip(),
+        ]
+
+    def _execute_state_ddl_statement(self, stmt: str) -> None:
+        if not self.connection:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        cursor = self.connection.cursor()
+        try:
+            cursor.execute(stmt)
+            self.connection.commit()
+        except Exception:
+            self.connection.rollback()
+            raise
+        finally:
+            cursor.close()
+
+    def insert_run_state(self, data_schema: str, run_id: str, manifest_json: str) -> None:
+        if not self.connection:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        table = self.state_table_ref(data_schema)
+        cursor = self.connection.cursor()
+        try:
+            cursor.execute(
+                f"INSERT INTO {table} (record_type, written_at, run_id, manifest_json) "
+                "VALUES ('run', CURRENT_TIMESTAMP, %s, %s)",
+                (run_id, manifest_json),
+            )
+            self.connection.commit()
+        except Exception:
+            self.connection.rollback()
+            raise
+        finally:
+            cursor.close()
+
+    def read_latest_run_state(self, data_schema: str) -> str | None:
+        if not self.connection:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        table = self.state_table_ref(data_schema)
+        cursor = self.connection.cursor()
+        try:
+            cursor.execute(
+                f"SELECT manifest_json FROM {table} "
+                "WHERE record_type = 'run' ORDER BY id DESC LIMIT 1"
+            )
+            row = cursor.fetchone()
+        finally:
+            cursor.close()
+        return row[0] if row else None
+
+    def insert_fingerprint_state(
+        self,
+        data_schema: str,
+        model_name: str,
+        sql_hash: str,
+        config_hash: str,
+        fingerprint: str,
+        fingerprint_spec_version: int,
+    ) -> None:
+        if not self.connection:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        table = self.state_table_ref(data_schema)
+        cursor = self.connection.cursor()
+        try:
+            cursor.execute(
+                f"INSERT INTO {table} "
+                "(record_type, written_at, model_name, sql_hash, config_hash, fingerprint, "
+                "fingerprint_spec_version) "
+                "VALUES ('fingerprint', CURRENT_TIMESTAMP, %s, %s, %s, %s, %s)",
+                (model_name, sql_hash, config_hash, fingerprint, fingerprint_spec_version),
+            )
+            self.connection.commit()
+        except Exception:
+            self.connection.rollback()
+            raise
+        finally:
+            cursor.close()
+
+    def read_fingerprint_state(self, data_schema: str, model_name: str) -> dict[str, Any] | None:
+        if not self.connection:
+            raise RuntimeError("Not connected to database. Call connect() first.")
+        table = self.state_table_ref(data_schema)
+        cursor = self.connection.cursor()
+        try:
+            cursor.execute(
+                "SELECT sql_hash, config_hash, fingerprint, fingerprint_spec_version, written_at "
+                f"FROM {table} WHERE record_type = 'fingerprint' AND model_name = %s "
+                "ORDER BY id DESC LIMIT 1",
+                (model_name,),
+            )
+            row = cursor.fetchone()
+        finally:
+            cursor.close()
+        if not row:
+            return None
+        return {
+            "sql_hash": row[0],
+            "config_hash": row[1],
+            "fingerprint": row[2],
+            "fingerprint_spec_version": row[3],
+            "updated_at": str(row[4]) if row[4] is not None else None,
+        }
+
 
 # Register the adapter
 register_adapter("postgresql", PostgreSQLAdapter)

--- a/t4t/adapters/snowflake/adapter.py
+++ b/t4t/adapters/snowflake/adapter.py
@@ -592,6 +592,102 @@ class SnowflakeAdapter(DatabaseAdapter):
             ) AS duplicate_groups
         """
 
+    # -- Warehouse state table (#20) --------------------------------------
+    #
+    # Snowflake supports the SQL-standard `GENERATED ALWAYS AS IDENTITY`
+    # column, used as the ordering column for `read_latest` (a
+    # database-native sequence, not a wall-clock timestamp -- #20's
+    # concurrency-ordering design decision). Not independently tested here
+    # against a live Snowflake connection (none available in this
+    # environment) -- this is documented Snowflake syntax, but see #20's
+    # implementation report for the exact scope of what was/wasn't verified
+    # against a real connection.
+    #
+    # Table references are DATABASE.SCHEMA.TABLE (three-part), matching
+    # every other qualified reference in this adapter (see
+    # `_qualify_object_name`).
+
+    def state_table_ref(self, data_schema: str) -> str:
+        return (
+            f"{self.config.database}.{self.state_schema_name(data_schema)}.{self.STATE_TABLE_NAME}"
+        )
+
+    def _state_table_ddl_statements(self, data_schema: str) -> list[str]:
+        qualified_schema = f"{self.config.database}.{self.state_schema_name(data_schema)}"
+        table = self.state_table_ref(data_schema)
+        return [
+            f"CREATE SCHEMA IF NOT EXISTS {qualified_schema}",
+            f"""
+            CREATE TABLE IF NOT EXISTS {table} (
+                id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                record_type VARCHAR(20) NOT NULL,
+                written_at TIMESTAMP_NTZ NOT NULL,
+                run_id VARCHAR,
+                manifest_json VARCHAR,
+                model_name VARCHAR,
+                sql_hash VARCHAR,
+                config_hash VARCHAR,
+                fingerprint VARCHAR,
+                fingerprint_spec_version INTEGER
+            )
+            """.strip(),
+        ]
+
+    def _execute_state_ddl_statement(self, stmt: str) -> None:
+        self._execute_with_cursor(stmt)
+
+    def insert_run_state(self, data_schema: str, run_id: str, manifest_json: str) -> None:
+        table = self.state_table_ref(data_schema)
+        self._execute_with_cursor(
+            f"INSERT INTO {table} (record_type, written_at, run_id, manifest_json) "
+            "VALUES ('run', CURRENT_TIMESTAMP(), %s, %s)",
+            (run_id, manifest_json),
+        )
+
+    def read_latest_run_state(self, data_schema: str) -> str | None:
+        table = self.state_table_ref(data_schema)
+        rows = self._execute_with_cursor(
+            f"SELECT manifest_json FROM {table} WHERE record_type = 'run' ORDER BY id DESC LIMIT 1"
+        )
+        return rows[0][0] if rows else None
+
+    def insert_fingerprint_state(
+        self,
+        data_schema: str,
+        model_name: str,
+        sql_hash: str,
+        config_hash: str,
+        fingerprint: str,
+        fingerprint_spec_version: int,
+    ) -> None:
+        table = self.state_table_ref(data_schema)
+        self._execute_with_cursor(
+            f"INSERT INTO {table} "
+            "(record_type, written_at, model_name, sql_hash, config_hash, fingerprint, "
+            "fingerprint_spec_version) "
+            "VALUES ('fingerprint', CURRENT_TIMESTAMP(), %s, %s, %s, %s, %s)",
+            (model_name, sql_hash, config_hash, fingerprint, fingerprint_spec_version),
+        )
+
+    def read_fingerprint_state(self, data_schema: str, model_name: str) -> dict[str, Any] | None:
+        table = self.state_table_ref(data_schema)
+        rows = self._execute_with_cursor(
+            "SELECT sql_hash, config_hash, fingerprint, fingerprint_spec_version, written_at "
+            f"FROM {table} WHERE record_type = 'fingerprint' AND model_name = %s "
+            "ORDER BY id DESC LIMIT 1",
+            (model_name,),
+        )
+        if not rows:
+            return None
+        row = rows[0]
+        return {
+            "sql_hash": row[0],
+            "config_hash": row[1],
+            "fingerprint": row[2],
+            "fingerprint_spec_version": row[3],
+            "updated_at": str(row[4]) if row[4] is not None else None,
+        }
+
 
 # Register the adapter
 register_adapter("snowflake", SnowflakeAdapter)

--- a/t4t/engine/config.py
+++ b/t4t/engine/config.py
@@ -106,6 +106,53 @@ def is_env_protected(project_folder: str | Path, env_name: str | None) -> bool:
         return False
 
 
+def get_state_backend_name(project_folder: str | Path, env_name: str | None) -> str:
+    """Read ``environments.<env>.state.backend`` from project.toml (#20).
+
+    Returns ``"local"`` -- today's behavior, fully backward compatible --
+    when: no environment is given, project.toml doesn't exist, the
+    environment has no ``[environments.<env>.state]`` section, or
+    ``backend`` is missing/unrecognized. Only ``"warehouse"`` selects
+    ``WarehouseStateBackend``; any other value (including a typo) is
+    treated as ``"local"`` with a warning, the same fail-safe-default
+    pattern as ``is_env_protected`` above.
+
+    Args:
+        project_folder: Path to the project folder containing project.toml.
+        env_name: The environment name to check. Returns "local" if None.
+
+    Returns:
+        ``"local"`` or ``"warehouse"``.
+    """
+    if not env_name:
+        return "local"
+    toml_path = Path(project_folder) / "project.toml"
+    if not toml_path.exists():
+        return "local"
+    try:
+        with open(toml_path, "rb") as f:
+            config = tomllib.load(f)
+        environments = config.get("environments", {})
+        env_config = environments.get(env_name, {})
+        if not isinstance(env_config, dict):
+            return "local"
+        state_config = env_config.get("state", {})
+        if not isinstance(state_config, dict):
+            return "local"
+        backend = state_config.get("backend", "local")
+        if backend not in ("local", "warehouse"):
+            logger.warning(
+                "Unrecognized state.backend %r for environment %r; using 'local'.",
+                backend,
+                env_name,
+            )
+            return "local"
+        return str(backend)
+    except Exception as e:
+        logger.warning("Could not read state.backend from project.toml: %s", e)
+        return "local"
+
+
 class DatabaseConfigManager:
     """Manages database configurations from multiple sources."""
 

--- a/t4t/executor.py
+++ b/t4t/executor.py
@@ -7,6 +7,7 @@ Handles the complete workflow of parsing and executing SQL models based on proje
 import logging
 from typing import TYPE_CHECKING, Any
 
+from t4t.adapters.base.state_table import StateTableDDLError
 from t4t.compiler import CompilationError, compile_project
 from t4t.engine import ModelExecutor
 from t4t.engine.config import is_env_protected
@@ -14,7 +15,8 @@ from t4t.engine.fingerprint import compute_project_fingerprints, store_project_f
 from t4t.executor_helpers import build_helpers, shared_helpers
 from t4t.parser import ProjectParser
 from t4t.parser.shared.exceptions import ParserError
-from t4t.state import LocalStateBackend, results_to_manifest, utc_now_iso
+from t4t.state import create_state_backend, results_to_manifest, utc_now_iso
+from t4t.state.warehouse_backend import WarehouseStateBackend
 
 if TYPE_CHECKING:
     from t4t.adapters import AdapterConfig
@@ -29,6 +31,7 @@ def _try_persist_run_manifest(
     command: str,
     started_at: str,
     *,
+    connection_config: dict[str, Any] | AdapterConfig | None = None,
     project_config: dict[str, Any] | None = None,
     variables: dict[str, Any] | None = None,
     function_names: set[str] | None = None,
@@ -39,7 +42,9 @@ def _try_persist_run_manifest(
     parsed_models: dict[str, Any] | None = None,
     dependency_graph: dict[str, Any] | None = None,
 ) -> None:
-    """Write last_run.json and append to runs.sqlite; failures are logged only.
+    """Persist the run manifest and fingerprints via the configured
+    StateBackend (#20 step 6: `environments.<env>.state.backend`, default
+    "local" -- `LocalStateBackend`, same as before this option existed).
 
     Also computes and stores each attempted model's fingerprint (#13 step 7):
     after the manifest is persisted, sql_hash/config_hash/fingerprint are
@@ -53,6 +58,14 @@ def _try_persist_run_manifest(
     upstream dependencies outside the selection still need their fingerprint
     computed to feed the hash chain, they're just not persisted here unless
     they were also attempted.
+
+    Failure handling is asymmetric on purpose (#20 acceptance criterion 3):
+    a `StateTableDDLError` (missing CREATE SCHEMA/CREATE TABLE permission
+    under the warehouse backend) is deliberately let through -- the whole
+    run must fail with that error, DDL text and all, not be swallowed into
+    a warning. Every other failure (e.g. local disk issues, a warehouse
+    connection blip) keeps the pre-existing best-effort "log only" behavior,
+    matching `LocalStateBackend`'s own failure-tolerant precedent.
     """
     logger = logging.getLogger(__name__)
     try:
@@ -73,15 +86,27 @@ def _try_persist_run_manifest(
             protected=protected,
             run_id=run_id,
         )
-        backend = LocalStateBackend(Path(project_folder) / "output", env_name=environment)
+        backend = create_state_backend(
+            project_folder, connection_config or {}, env_name=environment
+        )
+        attempted = {n.name for n in manifest.nodes if n.status in ("success", "failed")}
+
+        # Multi-schema partial-failure guard (#20 design decision): pre-create
+        # every touched data schema's state table in one pass, before any
+        # writes happen for this run, so a DDL failure on one schema fails
+        # the whole run rather than leaving some models tracked and others
+        # not.
+        if isinstance(backend, WarehouseStateBackend) and attempted:
+            backend.ensure_schemas_for_models(attempted)
+
         backend.append_run(manifest)
 
-        if parsed_models:
-            attempted = {n.name for n in manifest.nodes if n.status in ("success", "failed")}
-            if attempted:
-                graph = dependency_graph or {}
-                fingerprints = compute_project_fingerprints(parsed_models, graph)
-                store_project_fingerprints(backend, fingerprints, model_names=attempted)
+        if parsed_models and attempted:
+            graph = dependency_graph or {}
+            fingerprints = compute_project_fingerprints(parsed_models, graph)
+            store_project_fingerprints(backend, fingerprints, model_names=attempted)
+    except StateTableDDLError:
+        raise
     except Exception as e:
         logger.warning("Could not persist run manifest: %s", e)
 
@@ -190,6 +215,7 @@ def execute_models(
             empty,
             "run",
             run_started_at,
+            connection_config=connection_config,
             project_config=project_config,
             variables=variables,
             function_names=fnames or None,
@@ -233,6 +259,7 @@ def execute_models(
                 empty,
                 "run",
                 run_started_at,
+                connection_config=connection_config,
                 project_config=project_config,
                 variables=variables,
                 function_names=fnames or None,
@@ -320,6 +347,7 @@ def execute_models(
             results,
             "run",
             run_started_at,
+            connection_config=connection_config,
             project_config=project_config,
             variables=variables,
             function_names=fnames or None,
@@ -469,6 +497,7 @@ def build_models(
             empty_results,
             "build",
             build_started_at,
+            connection_config=connection_config,
             project_config=project_config,
             variables=variables,
             function_names=None,
@@ -556,6 +585,7 @@ def build_models(
             results,
             "build",
             build_started_at,
+            connection_config=connection_config,
             project_config=project_config,
             variables=variables,
             function_names=fn_build or None,

--- a/t4t/executor.py
+++ b/t4t/executor.py
@@ -7,7 +7,7 @@ Handles the complete workflow of parsing and executing SQL models based on proje
 import logging
 from typing import TYPE_CHECKING, Any
 
-from t4t.adapters.base.state_table import StateTableDDLError
+from t4t.adapters.base.state_table import SchemaEnsureError, StateTableDDLError
 from t4t.compiler import CompilationError, compile_project
 from t4t.engine import ModelExecutor
 from t4t.engine.config import is_env_protected
@@ -60,12 +60,18 @@ def _try_persist_run_manifest(
     they were also attempted.
 
     Failure handling is asymmetric on purpose (#20 acceptance criterion 3):
-    a `StateTableDDLError` (missing CREATE SCHEMA/CREATE TABLE permission
-    under the warehouse backend) is deliberately let through -- the whole
-    run must fail with that error, DDL text and all, not be swallowed into
-    a warning. Every other failure (e.g. local disk issues, a warehouse
-    connection blip) keeps the pre-existing best-effort "log only" behavior,
-    matching `LocalStateBackend`'s own failure-tolerant precedent.
+    any failure of the multi-schema pre-creation guard
+    (`WarehouseStateBackend.ensure_schemas_for_models`) is deliberately let
+    through -- whether it's a `StateTableDDLError` (missing CREATE SCHEMA/
+    CREATE TABLE permission) or any other exception (e.g. a transient
+    connection failure while opening the adapter, wrapped as
+    `SchemaEnsureError`) -- because either way we don't actually know
+    whether every touched data schema's state table exists, so the whole
+    run must fail rather than proceed with unknown/partial state coverage.
+    Every other failure *after* that guard has passed (e.g. local disk
+    issues, a warehouse connection blip during `append_run`/fingerprint
+    writes) keeps the pre-existing best-effort "log only" behavior, matching
+    `LocalStateBackend`'s own failure-tolerant precedent.
     """
     logger = logging.getLogger(__name__)
     try:
@@ -97,7 +103,19 @@ def _try_persist_run_manifest(
         # the whole run rather than leaving some models tracked and others
         # not.
         if isinstance(backend, WarehouseStateBackend) and attempted:
-            backend.ensure_schemas_for_models(attempted)
+            try:
+                backend.ensure_schemas_for_models(attempted)
+            except StateTableDDLError:
+                raise
+            except Exception as e:
+                # Any non-DDL failure here (e.g. a connection blip while
+                # opening the adapter) still means we don't know whether
+                # every touched schema's state table exists -- per #20's
+                # design decision this must fail the whole run too, not
+                # just permission-shaped failures. Wrap and re-raise so the
+                # outer `except Exception` below (which is best-effort by
+                # design for *other* persistence steps) doesn't swallow it.
+                raise SchemaEnsureError(e) from e
 
         backend.append_run(manifest)
 
@@ -105,7 +123,7 @@ def _try_persist_run_manifest(
             graph = dependency_graph or {}
             fingerprints = compute_project_fingerprints(parsed_models, graph)
             store_project_fingerprints(backend, fingerprints, model_names=attempted)
-    except StateTableDDLError:
+    except (StateTableDDLError, SchemaEnsureError):
         raise
     except Exception as e:
         logger.warning("Could not persist run manifest: %s", e)

--- a/t4t/state/__init__.py
+++ b/t4t/state/__init__.py
@@ -1,6 +1,7 @@
 """Run state: manifests, persistence, retry selection."""
 
 from t4t.state.backend import LocalStateBackend, StateBackend
+from t4t.state.factory import create_state_backend
 from t4t.state.fingerprint import StoredFingerprint
 from t4t.state.manifest import (
     SCHEMA_VERSION,
@@ -11,11 +12,14 @@ from t4t.state.manifest import (
     utc_now_iso,
 )
 from t4t.state.retry import compute_retry_set, prepare_retry_select_patterns
+from t4t.state.warehouse_backend import WarehouseStateBackend
 
 __all__ = [
     "SCHEMA_VERSION",
     "LocalStateBackend",
     "StateBackend",
+    "WarehouseStateBackend",
+    "create_state_backend",
     "StoredFingerprint",
     "RunManifest",
     "manifest_from_dict",

--- a/t4t/state/factory.py
+++ b/t4t/state/factory.py
@@ -1,0 +1,38 @@
+"""Backend selection: local (default) vs warehouse (#20 step 6).
+
+A single entry point used by every call site that used to construct
+``LocalStateBackend`` directly (``t4t/executor.py``, ``t4t/state/retry.py``)
+so ``environments.<env>.state.backend`` is the *only* thing that changes
+which backend a given (project, environment) pair gets -- omitting the
+config, or setting it to ``"local"``, is required to produce byte-for-byte
+the same ``LocalStateBackend`` construction as before this module existed
+(see ``tests/state/test_factory.py``'s regression-safety tests).
+"""
+
+from pathlib import Path
+from typing import Any
+
+from t4t.adapters.base import AdapterConfig
+from t4t.engine.config import get_state_backend_name
+from t4t.state.backend import LocalStateBackend, StateBackend
+from t4t.state.warehouse_backend import WarehouseStateBackend
+
+
+def create_state_backend(
+    project_folder: str | Path,
+    connection_config: AdapterConfig | dict[str, Any],
+    env_name: str | None = None,
+) -> StateBackend:
+    """Construct the ``StateBackend`` for a (project, environment) pair.
+
+    Reads ``environments.<env>.state.backend`` from ``project.toml``
+    (``"local"`` if omitted -- see ``get_state_backend_name``). ``"warehouse"``
+    constructs a ``WarehouseStateBackend`` using *connection_config* (the
+    same connection the environment's models already use -- no separate
+    credentials); anything else constructs the existing ``LocalStateBackend``
+    under ``<project_folder>/output``.
+    """
+    backend_name = get_state_backend_name(project_folder, env_name)
+    if backend_name == "warehouse":
+        return WarehouseStateBackend(connection_config, env_name=env_name)
+    return LocalStateBackend(Path(project_folder) / "output", env_name=env_name)

--- a/t4t/state/retry.py
+++ b/t4t/state/retry.py
@@ -3,12 +3,11 @@ Compute which models to re-run from a stored manifest (failed + downstream + ups
 """
 
 import logging
-from pathlib import Path
 from typing import Any
 
 from t4t.compiler import compile_project
 from t4t.executor_helpers.shared_helpers import validate_compile_results
-from t4t.state.backend import LocalStateBackend
+from t4t.state.factory import create_state_backend
 from t4t.state.manifest import SCHEMA_VERSION, RunManifest
 
 logger = logging.getLogger(__name__)
@@ -104,7 +103,7 @@ def prepare_retry_select_patterns(
         project_config=project_config,
     )
     graph, _, _ = validate_compile_results(compile_results)
-    backend = LocalStateBackend(Path(project_folder) / "output", env_name=env_name)
+    backend = create_state_backend(project_folder, connection_config, env_name=env_name)
     manifest = backend.read_latest()
     if manifest is None:
         raise ValueError(

--- a/t4t/state/warehouse_backend.py
+++ b/t4t/state/warehouse_backend.py
@@ -53,11 +53,20 @@ def _model_data_schema(adapter: Any, model_name: str) -> str:
     ``model_name`` -- e.g. ``analytics.orders`` -> ``analytics`` -- with the
     environment's naming strategy applied via ``apply_naming`` (the same
     path model execution itself uses), falling back to the environment's
-    default schema for an unqualified model name."""
+    default schema for an unqualified model name.
+
+    ``apply_naming`` can return either a two-part (``schema.table``, e.g.
+    DuckDB/PostgreSQL) or three-part (``database.schema.table``, e.g.
+    Snowflake/BigQuery) physical name. In both cases the schema is the
+    second-to-last dot-separated part -- the same convention
+    ``apply_naming`` itself uses to decide which part gets the
+    ``naming.schema_prefix`` (see ``t4t/adapters/base/core.py``). Naively
+    taking everything left of the last dot (``rpartition(".")``) would
+    incorrectly return ``database.schema`` for three-part names."""
     physical = adapter.apply_naming(model_name)
-    if "." in physical:
-        schema, _, _ = physical.rpartition(".")
-        return schema
+    parts = physical.split(".")
+    if len(parts) >= 2:
+        return parts[-2]
     return _default_data_schema(adapter)
 
 

--- a/t4t/state/warehouse_backend.py
+++ b/t4t/state/warehouse_backend.py
@@ -1,0 +1,187 @@
+"""WarehouseStateBackend: warehouse-table-backed pluggable state (#20).
+
+Stores run manifests and per-model fingerprints in the environment's own
+warehouse connection -- no separate credentials, no local disk -- so a fresh
+CI container (which has no local state at all) still has a real baseline to
+compare against for ``--retry`` and #14's ``definition:changed`` selection.
+
+Layout: one shared ``<schema>_STATE.t4t_model_state`` table per *data*
+schema (not per model table -- see #20's design decision), holding both
+run-manifest rows (``record_type = 'run'``) and per-model fingerprint rows
+(``record_type = 'fingerprint'``), auto-created on first use. DDL/DML for
+each adapter is hand-written on the adapter class itself (see
+``t4t/adapters/base/state_table.py`` and each adapter's "Warehouse state
+table (#20)" section) -- this module only orchestrates which schema each
+piece of state belongs in and implements the ``StateBackend`` Protocol.
+"""
+
+import json
+import logging
+from typing import Any
+
+from t4t.adapters import AdapterConfig, get_adapter
+from t4t.adapters.base.state_table import StateTableDDLError
+from t4t.state.fingerprint import StoredFingerprint
+from t4t.state.manifest import RunManifest, manifest_from_dict, manifest_to_dict
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["WarehouseStateBackend", "StateTableDDLError"]
+
+
+def _naming_prefixed(schema: str, adapter: Any) -> str:
+    """Apply the environment's ``naming.schema_prefix`` (if configured) to a
+    raw schema name -- so ``<schema>_STATE`` gets the same per-environment
+    isolation models themselves already get (e.g. sharing one physical
+    database across ``dev``/``prod`` via a schema prefix), not a raw,
+    environment-blind schema name that would collide across environments."""
+    naming = getattr(adapter.config, "naming", None)
+    prefix = getattr(naming, "schema_prefix", None) if naming else None
+    return f"{prefix}{schema}" if prefix else schema
+
+
+def _default_data_schema(adapter: Any) -> str:
+    """The data schema run-manifest rows are written to: the environment's
+    configured default schema (``connection.schema``, falling back to the
+    adapter's own default, e.g. DuckDB's ``main``), naming-prefixed."""
+    schema = adapter.config.schema or adapter._get_default_schema()
+    return _naming_prefixed(schema, adapter)
+
+
+def _model_data_schema(adapter: Any, model_name: str) -> str:
+    """The data schema a model belongs to, derived from its (dotted)
+    ``model_name`` -- e.g. ``analytics.orders`` -> ``analytics`` -- with the
+    environment's naming strategy applied via ``apply_naming`` (the same
+    path model execution itself uses), falling back to the environment's
+    default schema for an unqualified model name."""
+    physical = adapter.apply_naming(model_name)
+    if "." in physical:
+        schema, _, _ = physical.rpartition(".")
+        return schema
+    return _default_data_schema(adapter)
+
+
+class WarehouseStateBackend:
+    """``StateBackend`` Protocol implementation backed by the environment's
+    own warehouse connection.
+
+    Mirrors ``LocalStateBackend``'s constructor shape (an env-scoped
+    resource handle, not a long-lived open connection) but its storage
+    calls are genuinely different: every method opens its own short-lived
+    adapter connection, does its work, and disconnects. This matches
+    ``LocalStateBackend``'s own existing pattern of opening/closing a
+    sqlite3 connection per call (see ``t4t/state/backend.py``) rather than
+    introducing a new one -- and avoids holding a warehouse connection open
+    for the lifetime of a (potentially long) run.
+
+    Needs no separate credentials: ``connection_config`` is the same
+    ``AdapterConfig``/dict the environment's models already connect with.
+    """
+
+    def __init__(
+        self,
+        connection_config: AdapterConfig | dict[str, Any],
+        env_name: str | None = None,
+    ) -> None:
+        self.connection_config = connection_config
+        self.env_name = env_name
+
+    def _open_adapter(self) -> Any:
+        adapter = get_adapter(self.connection_config)
+        adapter.connect()
+        return adapter
+
+    # -- Multi-schema partial-failure guard --------------------------------
+
+    def ensure_schemas_for_models(self, model_names: set[str]) -> None:
+        """Pre-create every data schema's state table a run touches, in one
+        pass, before any state is written for that run.
+
+        Per #20's design decision: if schema/table creation succeeds for one
+        data schema and fails for another (different grants on each), the
+        WHOLE run must fail -- not just the failed schema -- since writing
+        state for some models and not others would make #14's
+        ``definition:changed`` silently wrong for exactly the untracked
+        models. Calling this up front (before any ``append_run``/
+        ``save_fingerprint`` calls) means a failure here happens before any
+        write, rather than partway through a per-model loop.
+
+        Raises ``StateTableDDLError`` (left uncaught -- callers should let
+        it propagate and fail the run) on the first schema that can't be
+        created.
+        """
+        adapter = self._open_adapter()
+        try:
+            schemas = {_default_data_schema(adapter)}
+            schemas.update(_model_data_schema(adapter, name) for name in model_names)
+            for schema in sorted(schemas):
+                adapter.ensure_state_table(schema)
+        finally:
+            adapter.disconnect()
+
+    # -- StateBackend Protocol ----------------------------------------------
+
+    def append_run(self, manifest: RunManifest) -> None:
+        payload = json.dumps(manifest_to_dict(manifest))
+        adapter = self._open_adapter()
+        try:
+            schema = _default_data_schema(adapter)
+            adapter.ensure_state_table(schema)
+            adapter.insert_run_state(schema, manifest.run_id, payload)
+        finally:
+            adapter.disconnect()
+
+    def read_latest(self) -> RunManifest | None:
+        adapter = self._open_adapter()
+        try:
+            schema = _default_data_schema(adapter)
+            adapter.ensure_state_table(schema)
+            payload = adapter.read_latest_run_state(schema)
+        finally:
+            adapter.disconnect()
+
+        if payload is None:
+            return None
+        try:
+            return manifest_from_dict(json.loads(payload))
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
+            logger.warning("Could not parse latest warehouse run manifest: %s", e)
+            return None
+
+    def save_fingerprint(
+        self,
+        model_name: str,
+        sql_hash: str,
+        config_hash: str,
+        fingerprint: str,
+        fingerprint_spec_version: int,
+    ) -> None:
+        adapter = self._open_adapter()
+        try:
+            schema = _model_data_schema(adapter, model_name)
+            adapter.ensure_state_table(schema)
+            adapter.insert_fingerprint_state(
+                schema, model_name, sql_hash, config_hash, fingerprint, fingerprint_spec_version
+            )
+        finally:
+            adapter.disconnect()
+
+    def read_fingerprint(self, model_name: str) -> StoredFingerprint | None:
+        adapter = self._open_adapter()
+        try:
+            schema = _model_data_schema(adapter, model_name)
+            adapter.ensure_state_table(schema)
+            row = adapter.read_fingerprint_state(schema, model_name)
+        finally:
+            adapter.disconnect()
+
+        if row is None:
+            return None
+        return StoredFingerprint(
+            model_name=model_name,
+            sql_hash=row["sql_hash"],
+            config_hash=row["config_hash"],
+            fingerprint=row["fingerprint"],
+            fingerprint_spec_version=int(row["fingerprint_spec_version"]),
+            updated_at=row.get("updated_at"),
+        )

--- a/tests/adapters/duckdb/test_state_table.py
+++ b/tests/adapters/duckdb/test_state_table.py
@@ -1,0 +1,119 @@
+"""#20 step 3/5: DuckDB warehouse state-table DDL/DML against a real connection.
+
+DuckDB is the one previously-asserted-then-disproven mechanism (#20's
+research found `GENERATED ALWAYS AS IDENTITY` unsupported on DuckDB, using
+`CREATE SEQUENCE` + `DEFAULT nextval(...)` instead), so it gets a real
+in-memory-connection test, not just the adapter-agnostic
+`StateTableMixin` unit tests in tests/adapters/test_state_table.py.
+"""
+
+from t4t.adapters.base.state_table import STATE_TABLE_NAME
+
+
+class TestDuckDBStateTableDDL:
+    def test_identity_column_not_supported_by_duckdb(self, duckdb_adapter):
+        """Sanity check for #20's design decision: DuckDB really does reject
+        `GENERATED ALWAYS AS IDENTITY` (this is *why* the DDL below uses
+        CREATE SEQUENCE + DEFAULT nextval(...) instead)."""
+        import pytest
+
+        with pytest.raises(Exception, match="not implemented|Constraint"):
+            duckdb_adapter.connection.execute(
+                "CREATE TABLE t_identity_probe (id BIGINT GENERATED ALWAYS AS IDENTITY)"
+            )
+
+    def test_ensure_state_table_creates_schema_and_table(self, duckdb_adapter):
+        duckdb_adapter.ensure_state_table("analytics")
+
+        schema_row = duckdb_adapter.connection.execute(
+            "SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = ?",
+            ["analytics_STATE"],
+        ).fetchone()
+        assert schema_row[0] == 1
+
+        table_row = duckdb_adapter.connection.execute(
+            "SELECT COUNT(*) FROM information_schema.tables "
+            "WHERE table_schema = ? AND table_name = ?",
+            ["analytics_STATE", STATE_TABLE_NAME],
+        ).fetchone()
+        assert table_row[0] == 1
+
+    def test_ensure_state_table_idempotent(self, duckdb_adapter):
+        duckdb_adapter.ensure_state_table("analytics")
+        duckdb_adapter.ensure_state_table("analytics")  # must not raise
+
+    def test_insert_and_read_latest_run_state(self, duckdb_adapter):
+        duckdb_adapter.ensure_state_table("analytics")
+        duckdb_adapter.insert_run_state("analytics", "run-1", '{"run_id": "run-1"}')
+        duckdb_adapter.insert_run_state("analytics", "run-2", '{"run_id": "run-2"}')
+
+        latest = duckdb_adapter.read_latest_run_state("analytics")
+        assert latest == '{"run_id": "run-2"}'
+
+    def test_read_latest_run_state_no_rows_returns_none(self, duckdb_adapter):
+        duckdb_adapter.ensure_state_table("analytics")
+        assert duckdb_adapter.read_latest_run_state("analytics") is None
+
+    def test_insert_and_read_fingerprint_state(self, duckdb_adapter):
+        duckdb_adapter.ensure_state_table("analytics")
+        duckdb_adapter.insert_fingerprint_state(
+            "analytics", "analytics.orders", "sql1", "cfg1", "fp1", 1
+        )
+
+        record = duckdb_adapter.read_fingerprint_state("analytics", "analytics.orders")
+        assert record is not None
+        assert record["sql_hash"] == "sql1"
+        assert record["config_hash"] == "cfg1"
+        assert record["fingerprint"] == "fp1"
+        assert record["fingerprint_spec_version"] == 1
+        assert record["updated_at"] is not None
+
+    def test_fingerprint_state_overwrite_returns_latest_by_ordering_column(self, duckdb_adapter):
+        """Insert-only (append-only): a second fingerprint write for the same
+        model is a new row, and `read_fingerprint_state` must return the one
+        with the higher `id` -- not the first-inserted row, and not
+        (necessarily) the one with the latest wall-clock `written_at`, which
+        is the whole point of using an ordering column (#20 step 8)."""
+        duckdb_adapter.ensure_state_table("analytics")
+        duckdb_adapter.insert_fingerprint_state(
+            "analytics", "analytics.orders", "sql-old", "cfg-old", "fp-old", 1
+        )
+        duckdb_adapter.insert_fingerprint_state(
+            "analytics", "analytics.orders", "sql-new", "cfg-new", "fp-new", 1
+        )
+
+        record = duckdb_adapter.read_fingerprint_state("analytics", "analytics.orders")
+        assert record["sql_hash"] == "sql-new"
+
+    def test_read_fingerprint_state_missing_model_returns_none(self, duckdb_adapter):
+        duckdb_adapter.ensure_state_table("analytics")
+        assert duckdb_adapter.read_fingerprint_state("analytics", "analytics.missing") is None
+
+    def test_ordering_by_id_not_insertion_or_timestamp(self, duckdb_adapter, monkeypatch):
+        """#20 step 8 / acceptance criterion 5: rows inserted out of
+        wall-clock order still come back ordered by the `id` sequence
+        column, not by `written_at`. We fake this by inserting a row with an
+        explicit, deliberately-earlier `written_at` *after* a row with a
+        later one, then asserting `read_latest_run_state` still returns the
+        row with the higher `id` (inserted second), matching #20's explicit
+        scope: this proves ordering-column correctness from sequential
+        calls, not concurrent-writer safety."""
+        duckdb_adapter.ensure_state_table("analytics")
+        table = duckdb_adapter.state_table_ref("analytics")
+
+        # Row 1: written_at far in the future.
+        duckdb_adapter.connection.execute(
+            f"INSERT INTO {table} (record_type, written_at, run_id, manifest_json) "
+            "VALUES ('run', TIMESTAMP '2099-01-01 00:00:00', ?, ?)",
+            ["run-early-id-future-clock", '{"run_id": "run-early-id-future-clock"}'],
+        )
+        # Row 2: written_at far in the past, but inserted (and so sequenced) second.
+        duckdb_adapter.connection.execute(
+            f"INSERT INTO {table} (record_type, written_at, run_id, manifest_json) "
+            "VALUES ('run', TIMESTAMP '2000-01-01 00:00:00', ?, ?)",
+            ["run-later-id-past-clock", '{"run_id": "run-later-id-past-clock"}'],
+        )
+
+        latest = duckdb_adapter.read_latest_run_state("analytics")
+        # The `id` sequence column, not `written_at`, decides "latest".
+        assert latest == '{"run_id": "run-later-id-past-clock"}'

--- a/tests/adapters/test_state_table.py
+++ b/tests/adapters/test_state_table.py
@@ -1,0 +1,106 @@
+"""#20 step 4: permission-denied path for warehouse state-table DDL.
+
+`StateTableMixin.ensure_state_table` must catch a DDL failure (e.g. a
+missing CREATE SCHEMA/CREATE TABLE grant) and raise `StateTableDDLError`
+with the literal DDL text, rather than letting a raw permission-denied
+exception propagate. Uses a minimal fake adapter, not a real connection --
+the real-connection DDL runs are covered separately per adapter (DuckDB:
+tests/adapters/duckdb/test_state_table_duckdb.py exercises this against a
+real in-memory connection).
+"""
+
+import pytest
+
+from t4t.adapters.base.state_table import StateTableDDLError, StateTableMixin
+
+
+class _PermissionDeniedAdapter(StateTableMixin):
+    """A fake adapter whose DDL always fails with a permission error."""
+
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+
+    def _state_table_ddl_statements(self, data_schema: str) -> list[str]:
+        schema = self.state_schema_name(data_schema)
+        table = self.state_table_ref(data_schema)
+        return [
+            f"CREATE SCHEMA IF NOT EXISTS {schema}",
+            f"CREATE TABLE IF NOT EXISTS {table} (id BIGINT)",
+        ]
+
+    def _execute_state_ddl_statement(self, stmt: str) -> None:
+        self.executed.append(stmt)
+        raise PermissionError("permission denied for database analytics")
+
+
+class _FailsOnSecondStatementAdapter(StateTableMixin):
+    """First DDL statement succeeds, second (the table) fails."""
+
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+
+    def _state_table_ddl_statements(self, data_schema: str) -> list[str]:
+        schema = self.state_schema_name(data_schema)
+        table = self.state_table_ref(data_schema)
+        return [
+            f"CREATE SCHEMA IF NOT EXISTS {schema}",
+            f"CREATE TABLE IF NOT EXISTS {table} (id BIGINT)",
+        ]
+
+    def _execute_state_ddl_statement(self, stmt: str) -> None:
+        self.executed.append(stmt)
+        if "CREATE TABLE" in stmt:
+            raise PermissionError("permission denied for schema analytics_STATE")
+
+
+class TestStateTableDDLError:
+    def test_permission_denied_raises_state_table_ddl_error(self) -> None:
+        adapter = _PermissionDeniedAdapter()
+        with pytest.raises(StateTableDDLError) as excinfo:
+            adapter.ensure_state_table("analytics")
+
+        err = excinfo.value
+        assert err.data_schema == "analytics"
+        assert isinstance(err.original, PermissionError)
+
+    def test_error_message_includes_literal_ddl_text(self) -> None:
+        adapter = _PermissionDeniedAdapter()
+        with pytest.raises(StateTableDDLError) as excinfo:
+            adapter.ensure_state_table("analytics")
+
+        message = str(excinfo.value)
+        assert "CREATE SCHEMA IF NOT EXISTS analytics_STATE" in message
+        assert "CREATE TABLE IF NOT EXISTS analytics_STATE.t4t_model_state" in message
+        # Not a raw traceback -- the underlying error is summarized, not dumped.
+        assert "permission denied" in message
+
+    def test_second_statement_failure_still_reports_all_ddl_text(self) -> None:
+        """A partial failure (schema created, table creation denied) must
+        still surface the *whole* DDL block -- an admin needs the schema
+        creation statement too, to run both from a clean slate."""
+        adapter = _FailsOnSecondStatementAdapter()
+        with pytest.raises(StateTableDDLError) as excinfo:
+            adapter.ensure_state_table("analytics")
+
+        assert adapter.executed == [
+            "CREATE SCHEMA IF NOT EXISTS analytics_STATE",
+            "CREATE TABLE IF NOT EXISTS analytics_STATE.t4t_model_state (id BIGINT)",
+        ]
+        message = str(excinfo.value)
+        assert "CREATE SCHEMA IF NOT EXISTS analytics_STATE" in message
+        assert "CREATE TABLE IF NOT EXISTS analytics_STATE.t4t_model_state" in message
+
+    def test_success_does_not_raise(self) -> None:
+        class _SucceedsAdapter(StateTableMixin):
+            def __init__(self) -> None:
+                self.executed: list[str] = []
+
+            def _state_table_ddl_statements(self, data_schema: str) -> list[str]:
+                return [f"CREATE SCHEMA IF NOT EXISTS {self.state_schema_name(data_schema)}"]
+
+            def _execute_state_ddl_statement(self, stmt: str) -> None:
+                self.executed.append(stmt)
+
+        adapter = _SucceedsAdapter()
+        adapter.ensure_state_table("analytics")
+        assert adapter.executed == ["CREATE SCHEMA IF NOT EXISTS analytics_STATE"]

--- a/tests/cli/test_warehouse_state_e2e.py
+++ b/tests/cli/test_warehouse_state_e2e.py
@@ -1,0 +1,189 @@
+"""#20 step 9: the acceptance test -- the actual merge gate.
+
+Runs `t4t run` through Typer's in-process `CliRunner` (unlike #13's
+subprocess-isolated fingerprint e2e test, this one has no
+process-global-state concern to isolate against) against a real project
+copied from tests/fixtures/warehouse_state_project/, with a real DuckDB
+connection -- not mocked backend calls.
+
+Covers all 5 acceptance criteria from the issue: case 4 (backend-switch
+fail-open) is also covered directly against the backend in
+tests/state/test_backend_switch.py, but is included here too at the full
+CLI level since component tests alone don't close this issue per the issue
+text.
+"""
+
+import shutil
+from pathlib import Path
+
+import duckdb
+import pytest
+from typer.testing import CliRunner
+
+from t4t.adapters.duckdb.adapter import DuckDBAdapter
+from t4t.cli.main import app
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "warehouse_state_project"
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    dest = tmp_path / "warehouse_state_project"
+    shutil.copytree(FIXTURE, dest)
+    (dest / "data").mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+def _state_rows(db_path: Path, schema: str) -> list[tuple]:
+    conn = duckdb.connect(str(db_path))
+    try:
+        return conn.execute(
+            f"SELECT record_type, model_name, run_id FROM {schema}_STATE.t4t_model_state "
+            "ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+class TestWarehouseBackendAcceptance:
+    def test_criterion_1_run_populates_warehouse_state_table(self, project: Path) -> None:
+        """`backend = "warehouse"`: after `t4t run --env dev`, querying
+        `<schema>_STATE.t4t_model_state` directly on the actual configured
+        connection returns the expected model-state rows."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["run", str(project), "--env", "dev"], catch_exceptions=False)
+        assert result.exit_code == 0, result.stdout
+
+        db_path = project / "data" / "warehouse_state_project.duckdb"
+        rows = _state_rows(db_path, "wst")
+
+        record_types = {r[0] for r in rows}
+        assert "run" in record_types
+        assert "fingerprint" in record_types
+
+        fingerprint_models = {r[1] for r in rows if r[0] == "fingerprint"}
+        assert fingerprint_models == {"wst.a", "wst.b"}
+
+    def test_criterion_2_backend_omitted_behaves_exactly_like_before(self, project: Path) -> None:
+        """`backend` omitted (or "local"): behavior is byte-for-byte
+        unchanged from before this issue -- no warehouse schema is ever
+        created, and last_run.json/runs.sqlite are written exactly as
+        `LocalStateBackend` always has."""
+        toml_path = project / "project.toml"
+        toml_path.write_text(
+            toml_path.read_text(encoding="utf-8").replace(
+                '\n[environments.dev.state]\nbackend = "warehouse"\n', ""
+            ),
+            encoding="utf-8",
+        )
+        assert "[environments.dev.state]" not in toml_path.read_text(encoding="utf-8")
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["run", str(project), "--env", "dev"], catch_exceptions=False)
+        assert result.exit_code == 0, result.stdout
+
+        assert (project / "output" / "dev" / "last_run.json").is_file()
+        assert (project / "output" / "dev" / "runs.sqlite").is_file()
+
+        db_path = project / "data" / "warehouse_state_project.duckdb"
+        conn = duckdb.connect(str(db_path))
+        try:
+            schemas = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT schema_name FROM information_schema.schemata"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        assert "wst_STATE" not in schemas
+
+    def test_criterion_5_ordering_by_id_across_two_real_runs(self, project: Path) -> None:
+        """Rows from a second real `t4t run` sort after the first by the
+        ordering column -- proven at the CLI level (two full, real
+        invocations), not just direct adapter calls."""
+        runner = CliRunner()
+        r1 = runner.invoke(app, ["run", str(project), "--env", "dev"], catch_exceptions=False)
+        assert r1.exit_code == 0, r1.stdout
+        r2 = runner.invoke(app, ["run", str(project), "--env", "dev"], catch_exceptions=False)
+        assert r2.exit_code == 0, r2.stdout
+
+        db_path = project / "data" / "warehouse_state_project.duckdb"
+        run_rows = [r for r in _state_rows(db_path, "wst") if r[0] == "run"]
+        assert len(run_rows) == 2
+        # Second run's run_id must sort after the first's by `id` (insertion
+        # order here, matching wall-clock order too -- the out-of-order case
+        # is covered directly against the adapter in
+        # tests/adapters/duckdb/test_state_table_duckdb.py).
+        assert run_rows[0][2] != run_rows[1][2]
+
+    def test_criterion_3_missing_create_schema_permission_fails_with_ddl_text(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing CREATE SCHEMA permission: the run fails with an error
+        that includes the literal DDL text, not a raw permission-denied
+        traceback."""
+
+        original = DuckDBAdapter._execute_state_ddl_statement
+
+        def _permission_denied(self, stmt: str):
+            if "CREATE SCHEMA" in stmt:
+                raise RuntimeError("permission denied for database warehouse_state_project")
+            return original(self, stmt)
+
+        monkeypatch.setattr(DuckDBAdapter, "_execute_state_ddl_statement", _permission_denied)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["run", str(project), "--env", "dev"], catch_exceptions=True)
+
+        assert result.exit_code != 0
+        output = result.stdout + str(result.exception or "")
+        assert "CREATE SCHEMA IF NOT EXISTS wst_STATE" in output
+        assert "permission denied" in output
+        # Not a raw traceback dumped to the user by default (non-verbose).
+        assert "Traceback (most recent call last)" not in result.stdout
+
+    def test_criterion_4_switching_local_to_warehouse_between_cli_runs(self, project: Path) -> None:
+        """Switching `local` -> `warehouse` between two `t4t run` invocations:
+        the first run under the new backend has no baseline -- proven here
+        by asserting the warehouse state table is untouched by the run that
+        happened while the environment was still on `local`."""
+        toml_path = project / "project.toml"
+        original_toml = toml_path.read_text(encoding="utf-8")
+        local_toml = original_toml.replace('backend = "warehouse"', 'backend = "local"')
+        assert local_toml != original_toml  # sanity: the replace actually matched
+        toml_path.write_text(local_toml, encoding="utf-8")
+
+        runner = CliRunner()
+        r1 = runner.invoke(app, ["run", str(project), "--env", "dev"], catch_exceptions=False)
+        assert r1.exit_code == 0, r1.stdout
+        assert (project / "output" / "dev" / "last_run.json").is_file()
+
+        # The local backend still runs the actual models against this same
+        # DuckDB file (it's the data connection, not something exclusive to
+        # the warehouse state backend) -- but it must never create the
+        # wst_STATE schema, since state itself stayed on local disk.
+        db_path = project / "data" / "warehouse_state_project.duckdb"
+        conn = duckdb.connect(str(db_path))
+        try:
+            schemas = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT schema_name FROM information_schema.schemata"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        assert "wst_STATE" not in schemas
+
+        # Switch to warehouse and run again.
+        toml_path.write_text(original_toml, encoding="utf-8")
+        r2 = runner.invoke(app, ["run", str(project), "--env", "dev"], catch_exceptions=False)
+        assert r2.exit_code == 0, r2.stdout
+
+        rows = _state_rows(db_path, "wst")
+        run_rows = [r for r in rows if r[0] == "run"]
+        # Exactly one warehouse run row -- the local run never wrote here,
+        # and this run has no warehouse baseline to have "misread".
+        assert len(run_rows) == 1

--- a/tests/executor/test_try_persist_run_manifest.py
+++ b/tests/executor/test_try_persist_run_manifest.py
@@ -2,14 +2,24 @@
 CREATE SCHEMA permission under the warehouse backend) must fail the whole
 `t4t run`/`t4t build` -- not be swallowed into `_try_persist_run_manifest`'s
 usual best-effort "log a warning and continue" handling, which every other
-persistence failure still gets (regression safety)."""
+persistence failure still gets (regression safety).
+
+This also covers the code-review fix for non-DDL failures of the
+multi-schema pre-creation guard itself (`ensure_schemas_for_models`): per
+#20's design decision ("a run touching multiple data schemas fails as a
+whole if any schema's DDL fails"), that guard must abort the whole run on
+*any* failure -- a transient connection blip included -- not just DDL/
+permission errors, since either way we don't know if every touched schema's
+state table exists. Only failures *after* the guard has already succeeded
+(e.g. during `append_run`/fingerprint writes) keep the pre-existing
+best-effort "log only" behavior."""
 
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from t4t.adapters.base.state_table import StateTableDDLError
+from t4t.adapters.base.state_table import SchemaEnsureError, StateTableDDLError
 from t4t.executor import _try_persist_run_manifest
 from t4t.state.warehouse_backend import WarehouseStateBackend
 
@@ -58,12 +68,44 @@ class TestStateTableDDLErrorPropagates:
                 run_id="run-1",
             )
 
-    def test_other_exceptions_still_logged_and_swallowed(
+    def test_non_ddl_error_from_ensure_schemas_also_fails_whole_run(self, tmp_path: Path) -> None:
+        """A non-DDL failure of the pre-creation guard itself (e.g. a
+        transient connection error, not a permission problem) must still
+        fail the whole run -- code-review fix for finding #3: this
+        previously fell through to the generic `except Exception` handler
+        and was silently logged-and-swallowed, letting the run continue
+        with unknown/partial state coverage."""
+        connection_config = {"type": "duckdb", "path": str(tmp_path / "state.duckdb")}
+
+        with (
+            patch(
+                "t4t.executor.create_state_backend",
+                return_value=WarehouseStateBackend(connection_config, env_name="prod"),
+            ),
+            patch.object(
+                WarehouseStateBackend,
+                "ensure_schemas_for_models",
+                side_effect=RuntimeError("transient connection blip"),
+            ),
+            pytest.raises(SchemaEnsureError, match="transient connection blip"),
+        ):
+            _try_persist_run_manifest(
+                str(tmp_path),
+                _minimal_run_results(),
+                "run",
+                "2026-01-01T00:00:00+00:00",
+                connection_config=connection_config,
+                environment="prod",
+                run_id="run-1",
+            )
+
+    def test_other_exceptions_after_guard_still_logged_and_swallowed(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """Regression safety: a non-DDL failure (e.g. a transient warehouse
-        connection error) must keep today's best-effort behavior -- log a
-        warning, don't raise, don't fail the run. Asserted via captured
+        """Regression safety: a failure *after* the pre-creation guard has
+        already succeeded (e.g. a transient warehouse connection error
+        during `append_run`) must keep today's best-effort behavior -- log
+        a warning, don't raise, don't fail the run. Asserted via captured
         stdout (t4t's own text-format log handler, installed by the autouse
         `_configure_t4t_logging` fixture) rather than `caplog`, since t4t's
         logging setup routes through its own handler rather than the
@@ -78,6 +120,11 @@ class TestStateTableDDLErrorPropagates:
             patch.object(
                 WarehouseStateBackend,
                 "ensure_schemas_for_models",
+                return_value=None,
+            ),
+            patch.object(
+                WarehouseStateBackend,
+                "append_run",
                 side_effect=RuntimeError("transient connection blip"),
             ),
         ):

--- a/tests/executor/test_try_persist_run_manifest.py
+++ b/tests/executor/test_try_persist_run_manifest.py
@@ -1,0 +1,110 @@
+"""#20 step 4 / acceptance criterion 3: a StateTableDDLError (e.g. missing
+CREATE SCHEMA permission under the warehouse backend) must fail the whole
+`t4t run`/`t4t build` -- not be swallowed into `_try_persist_run_manifest`'s
+usual best-effort "log a warning and continue" handling, which every other
+persistence failure still gets (regression safety)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from t4t.adapters.base.state_table import StateTableDDLError
+from t4t.executor import _try_persist_run_manifest
+from t4t.state.warehouse_backend import WarehouseStateBackend
+
+
+def _minimal_run_results() -> dict:
+    return {
+        "executed_tables": ["analytics.a"],
+        "failed_tables": [],
+        "executed_functions": [],
+        "failed_functions": [],
+        "table_info": {"analytics.a": {"row_count": 1, "materialization": "table"}},
+        "analysis": {
+            "execution_order": ["analytics.a"],
+            "dependency_graph": {"dependencies": {}},
+        },
+    }
+
+
+class TestStateTableDDLErrorPropagates:
+    def test_ddl_error_from_ensure_schemas_is_not_swallowed(self, tmp_path: Path) -> None:
+        connection_config = {"type": "duckdb", "path": str(tmp_path / "state.duckdb")}
+
+        with (
+            patch(
+                "t4t.executor.create_state_backend",
+                return_value=WarehouseStateBackend(connection_config, env_name="prod"),
+            ),
+            patch.object(
+                WarehouseStateBackend,
+                "ensure_schemas_for_models",
+                side_effect=StateTableDDLError(
+                    "analytics",
+                    ["CREATE SCHEMA IF NOT EXISTS analytics_STATE"],
+                    PermissionError("nope"),
+                ),
+            ),
+            pytest.raises(StateTableDDLError, match="CREATE SCHEMA IF NOT EXISTS analytics_STATE"),
+        ):
+            _try_persist_run_manifest(
+                str(tmp_path),
+                _minimal_run_results(),
+                "run",
+                "2026-01-01T00:00:00+00:00",
+                connection_config=connection_config,
+                environment="prod",
+                run_id="run-1",
+            )
+
+    def test_other_exceptions_still_logged_and_swallowed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Regression safety: a non-DDL failure (e.g. a transient warehouse
+        connection error) must keep today's best-effort behavior -- log a
+        warning, don't raise, don't fail the run. Asserted via captured
+        stdout (t4t's own text-format log handler, installed by the autouse
+        `_configure_t4t_logging` fixture) rather than `caplog`, since t4t's
+        logging setup routes through its own handler rather than the
+        handler `caplog` attaches to."""
+        connection_config = {"type": "duckdb", "path": str(tmp_path / "state.duckdb")}
+
+        with (
+            patch(
+                "t4t.executor.create_state_backend",
+                return_value=WarehouseStateBackend(connection_config, env_name="prod"),
+            ),
+            patch.object(
+                WarehouseStateBackend,
+                "ensure_schemas_for_models",
+                side_effect=RuntimeError("transient connection blip"),
+            ),
+        ):
+            # Must not raise.
+            _try_persist_run_manifest(
+                str(tmp_path),
+                _minimal_run_results(),
+                "run",
+                "2026-01-01T00:00:00+00:00",
+                connection_config=connection_config,
+                environment="prod",
+                run_id="run-1",
+            )
+        captured = capsys.readouterr()
+        assert "Could not persist run manifest" in captured.out
+
+    def test_local_backend_path_unaffected(self, tmp_path: Path) -> None:
+        """No environment -> local backend -> no ensure_schemas_for_models
+        call at all (it's a WarehouseStateBackend-only concept); the run
+        manifest still persists normally."""
+        connection_config = {"type": "duckdb", "path": ":memory:"}
+        _try_persist_run_manifest(
+            str(tmp_path),
+            _minimal_run_results(),
+            "run",
+            "2026-01-01T00:00:00+00:00",
+            connection_config=connection_config,
+            run_id="run-1",
+        )
+        assert (tmp_path / "output" / "last_run.json").is_file()

--- a/tests/fixtures/warehouse_state_project/models/wst/a.sql
+++ b/tests/fixtures/warehouse_state_project/models/wst/a.sql
@@ -1,0 +1,1 @@
+SELECT 1 AS id

--- a/tests/fixtures/warehouse_state_project/models/wst/b.sql
+++ b/tests/fixtures/warehouse_state_project/models/wst/b.sql
@@ -1,0 +1,1 @@
+SELECT id FROM a

--- a/tests/fixtures/warehouse_state_project/project.toml
+++ b/tests/fixtures/warehouse_state_project/project.toml
@@ -1,0 +1,9 @@
+project_folder = "warehouse_state_project"
+
+[environments.dev.connection]
+type = "duckdb"
+path = "data/warehouse_state_project.duckdb"
+schema = "wst"
+
+[environments.dev.state]
+backend = "warehouse"

--- a/tests/state/test_backend_switch.py
+++ b/tests/state/test_backend_switch.py
@@ -1,0 +1,110 @@
+"""#20 step 7 / acceptance criterion 4: switching `local` -> `warehouse` (or
+back) between two runs of the same project produces the documented
+no-migration, fail-open-on-missing-baseline behavior -- the first run under
+the new backend treats every model as having no baseline (fail-open,
+matching #13's fingerprint_spec_version-mismatch philosophy), not a crash
+and not a misread of the old backend's state.
+"""
+
+from pathlib import Path
+
+from t4t.state.factory import create_state_backend
+
+
+def _write_project_toml(project_folder: Path, backend: str) -> None:
+    (project_folder / "project.toml").write_text(
+        f"""
+        [environments.prod.state]
+        backend = "{backend}"
+        """,
+        encoding="utf-8",
+    )
+
+
+class TestLocalToWarehouseSwitch:
+    def test_run_manifest_not_visible_after_switching_to_warehouse(self, tmp_path: Path) -> None:
+        connection_config = {"type": "duckdb", "path": str(tmp_path / "data.duckdb")}
+
+        _write_project_toml(tmp_path, "local")
+        local_backend = create_state_backend(tmp_path, connection_config, env_name="prod")
+        from t4t.state.manifest import NodeResult, RunManifest
+
+        manifest = RunManifest(
+            schema_version=2,
+            t4t_version="0.1.0",
+            run_id="run-under-local",
+            command="run",
+            started_at="2026-01-01T00:00:00+00:00",
+            finished_at="2026-01-01T00:01:00+00:00",
+            project_root=str(tmp_path),
+            config_hash=None,
+            vars_hash=None,
+            execution_order=["analytics.a"],
+            nodes=[NodeResult(name="analytics.a", status="success", row_count=1)],
+            functions=[],
+        )
+        local_backend.append_run(manifest)
+        assert local_backend.read_latest().run_id == "run-under-local"
+
+        # Switch the environment to the warehouse backend between runs.
+        _write_project_toml(tmp_path, "warehouse")
+        warehouse_backend = create_state_backend(tmp_path, connection_config, env_name="prod")
+
+        # Fail-open: no crash, no misread of the local run -- simply no
+        # baseline yet under the new backend.
+        assert warehouse_backend.read_latest() is None
+
+    def test_fingerprint_not_visible_after_switching_to_warehouse(self, tmp_path: Path) -> None:
+        connection_config = {"type": "duckdb", "path": str(tmp_path / "data.duckdb")}
+
+        _write_project_toml(tmp_path, "local")
+        local_backend = create_state_backend(tmp_path, connection_config, env_name="prod")
+        local_backend.save_fingerprint("analytics.orders", "s1", "c1", "f1", 1)
+        assert local_backend.read_fingerprint("analytics.orders") is not None
+
+        _write_project_toml(tmp_path, "warehouse")
+        warehouse_backend = create_state_backend(tmp_path, connection_config, env_name="prod")
+        assert warehouse_backend.read_fingerprint("analytics.orders") is None
+
+
+class TestWarehouseToLocalSwitch:
+    def test_run_manifest_not_visible_after_switching_to_local(self, tmp_path: Path) -> None:
+        connection_config = {"type": "duckdb", "path": str(tmp_path / "data.duckdb")}
+
+        _write_project_toml(tmp_path, "warehouse")
+        warehouse_backend = create_state_backend(tmp_path, connection_config, env_name="prod")
+        from t4t.state.manifest import NodeResult, RunManifest
+
+        manifest = RunManifest(
+            schema_version=2,
+            t4t_version="0.1.0",
+            run_id="run-under-warehouse",
+            command="run",
+            started_at="2026-01-01T00:00:00+00:00",
+            finished_at="2026-01-01T00:01:00+00:00",
+            project_root=str(tmp_path),
+            config_hash=None,
+            vars_hash=None,
+            execution_order=["analytics.a"],
+            nodes=[NodeResult(name="analytics.a", status="success", row_count=1)],
+            functions=[],
+        )
+        warehouse_backend.append_run(manifest)
+        assert warehouse_backend.read_latest().run_id == "run-under-warehouse"
+
+        _write_project_toml(tmp_path, "local")
+        local_backend = create_state_backend(tmp_path, connection_config, env_name="prod")
+        assert local_backend.read_latest() is None
+
+    def test_switching_does_not_raise(self, tmp_path: Path) -> None:
+        """Explicitly: no crash in either direction, for both read paths."""
+        connection_config = {"type": "duckdb", "path": str(tmp_path / "data.duckdb")}
+
+        _write_project_toml(tmp_path, "warehouse")
+        warehouse_backend = create_state_backend(tmp_path, connection_config, env_name="prod")
+        warehouse_backend.save_fingerprint("analytics.orders", "s1", "c1", "f1", 1)
+
+        _write_project_toml(tmp_path, "local")
+        local_backend = create_state_backend(tmp_path, connection_config, env_name="prod")
+        assert local_backend.read_fingerprint("analytics.orders") is None
+        assert local_backend.read_latest() is None

--- a/tests/state/test_factory.py
+++ b/tests/state/test_factory.py
@@ -1,0 +1,200 @@
+"""#20 step 6: backend selection wiring.
+
+`create_state_backend` is the single place `environments.<env>.state.backend`
+gets read to decide which `StateBackend` implementation a (project,
+environment) pair gets. The critical regression-safety property: omitting
+the config entirely (or setting it to "local") must construct exactly the
+same `LocalStateBackend` as before this option existed.
+"""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from t4t.engine.config import get_state_backend_name
+from t4t.state.backend import LocalStateBackend
+from t4t.state.factory import create_state_backend
+from t4t.state.warehouse_backend import WarehouseStateBackend
+
+
+def _write_project_toml(project_folder: Path, body: str) -> None:
+    (project_folder / "project.toml").write_text(body, encoding="utf-8")
+
+
+class TestGetStateBackendName:
+    def test_no_env_name_returns_local(self, tmp_path: Path) -> None:
+        assert get_state_backend_name(tmp_path, None) == "local"
+
+    def test_no_project_toml_returns_local(self, tmp_path: Path) -> None:
+        assert get_state_backend_name(tmp_path, "dev") == "local"
+
+    def test_env_with_no_state_section_returns_local(self, tmp_path: Path) -> None:
+        _write_project_toml(
+            tmp_path,
+            """
+            [environments.dev.connection]
+            type = "duckdb"
+            path = "data/dev.duckdb"
+            """,
+        )
+        assert get_state_backend_name(tmp_path, "dev") == "local"
+
+    def test_explicit_local_returns_local(self, tmp_path: Path) -> None:
+        _write_project_toml(
+            tmp_path,
+            """
+            [environments.dev.state]
+            backend = "local"
+            """,
+        )
+        assert get_state_backend_name(tmp_path, "dev") == "local"
+
+    def test_warehouse_returns_warehouse(self, tmp_path: Path) -> None:
+        _write_project_toml(
+            tmp_path,
+            """
+            [environments.prod.state]
+            backend = "warehouse"
+            """,
+        )
+        assert get_state_backend_name(tmp_path, "prod") == "warehouse"
+
+    def test_unrecognized_value_falls_back_to_local(self, tmp_path: Path) -> None:
+        _write_project_toml(
+            tmp_path,
+            """
+            [environments.dev.state]
+            backend = "s3"
+            """,
+        )
+        assert get_state_backend_name(tmp_path, "dev") == "local"
+
+    def test_other_environment_unaffected(self, tmp_path: Path) -> None:
+        """Config is per-environment: a `warehouse` backend for `prod` must
+        not leak into `dev`."""
+        _write_project_toml(
+            tmp_path,
+            """
+            [environments.prod.state]
+            backend = "warehouse"
+
+            [environments.dev.state]
+            backend = "local"
+            """,
+        )
+        assert get_state_backend_name(tmp_path, "prod") == "warehouse"
+        assert get_state_backend_name(tmp_path, "dev") == "local"
+
+    def test_toml_round_trips_as_expected_by_tomllib(self, tmp_path: Path) -> None:
+        """Sanity check on the fixture bodies themselves: confirms the nested
+        table syntax used above actually parses to
+        `environments.<env>.state.backend`, not some other shape."""
+        _write_project_toml(
+            tmp_path,
+            """
+            [environments.prod.state]
+            backend = "warehouse"
+            """,
+        )
+        with open(tmp_path / "project.toml", "rb") as f:
+            parsed = tomllib.load(f)
+        assert parsed["environments"]["prod"]["state"]["backend"] == "warehouse"
+
+
+class TestCreateStateBackend:
+    def test_no_env_name_returns_local_backend(self, tmp_path: Path) -> None:
+        backend = create_state_backend(tmp_path, {"type": "duckdb", "path": ":memory:"})
+        assert isinstance(backend, LocalStateBackend)
+        assert backend.output_dir == tmp_path / "output"
+        assert backend.env_name is None
+
+    def test_omitted_config_produces_identical_local_backend(self, tmp_path: Path) -> None:
+        """Regression safety (#20 acceptance criterion 2): the exact
+        construction LocalStateBackend used before create_state_backend
+        existed."""
+        _write_project_toml(
+            tmp_path,
+            """
+            [environments.dev.connection]
+            type = "duckdb"
+            path = "data/dev.duckdb"
+            """,
+        )
+        backend = create_state_backend(
+            tmp_path, {"type": "duckdb", "path": ":memory:"}, env_name="dev"
+        )
+        direct = LocalStateBackend(tmp_path / "output", env_name="dev")
+
+        assert isinstance(backend, LocalStateBackend)
+        assert backend.output_dir == direct.output_dir
+        assert backend.env_name == direct.env_name
+        assert backend._scoped_dir == direct._scoped_dir  # noqa: SLF001
+
+    def test_explicit_local_produces_local_backend(self, tmp_path: Path) -> None:
+        _write_project_toml(
+            tmp_path,
+            """
+            [environments.dev.state]
+            backend = "local"
+            """,
+        )
+        backend = create_state_backend(
+            tmp_path, {"type": "duckdb", "path": ":memory:"}, env_name="dev"
+        )
+        assert isinstance(backend, LocalStateBackend)
+
+    def test_warehouse_produces_warehouse_backend(self, tmp_path: Path) -> None:
+        _write_project_toml(
+            tmp_path,
+            """
+            [environments.prod.state]
+            backend = "warehouse"
+            """,
+        )
+        connection_config = {"type": "duckdb", "path": str(tmp_path / "state.duckdb")}
+        backend = create_state_backend(tmp_path, connection_config, env_name="prod")
+        assert isinstance(backend, WarehouseStateBackend)
+        assert backend.connection_config == connection_config
+        assert backend.env_name == "prod"
+
+    def test_end_to_end_local_backend_roundtrip_unchanged(self, tmp_path: Path) -> None:
+        """Behavior, not just type: append_run/read_latest through the
+        factory-selected local backend behaves exactly like constructing
+        LocalStateBackend directly."""
+        from t4t.state.manifest import NodeResult, RunManifest
+
+        manifest = RunManifest(
+            schema_version=2,
+            t4t_version="0.1.0",
+            run_id="run-1",
+            command="run",
+            started_at="2026-01-01T00:00:00+00:00",
+            finished_at="2026-01-01T00:01:00+00:00",
+            project_root=str(tmp_path),
+            config_hash=None,
+            vars_hash=None,
+            execution_order=["a"],
+            nodes=[NodeResult(name="a", status="success", row_count=1)],
+            functions=[],
+        )
+        backend = create_state_backend(tmp_path, {"type": "duckdb", "path": ":memory:"})
+        backend.append_run(manifest)
+
+        direct = LocalStateBackend(tmp_path / "output")
+        read_back = direct.read_latest()
+        assert read_back is not None
+        assert read_back.run_id == "run-1"
+
+
+@pytest.mark.parametrize("backend_value", ["local", None])
+def test_local_is_the_default_backend(tmp_path: Path, backend_value) -> None:
+    if backend_value is not None:
+        _write_project_toml(
+            tmp_path,
+            f"""
+            [environments.dev.state]
+            backend = "{backend_value}"
+            """,
+        )
+    assert get_state_backend_name(tmp_path, "dev") == "local"

--- a/tests/state/test_warehouse_backend.py
+++ b/tests/state/test_warehouse_backend.py
@@ -4,13 +4,16 @@ each call opens its own short-lived connection, so an in-memory database
 would not persist data across calls, unlike a real warehouse)."""
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+from t4t.adapters.base import DatabaseAdapter
+from t4t.adapters.base.config import MaterializationType
 from t4t.state.backend import StateBackend
 from t4t.state.fingerprint import StoredFingerprint
 from t4t.state.manifest import NodeResult, RunManifest
-from t4t.state.warehouse_backend import WarehouseStateBackend
+from t4t.state.warehouse_backend import WarehouseStateBackend, _model_data_schema
 
 
 def _connection_config(db_path: Path, schema: str = "analytics") -> dict:
@@ -188,3 +191,119 @@ class TestEnsureSchemasForModels:
         backend = WarehouseStateBackend(_connection_config(db_path, schema="analytics"))
         with pytest.raises(RuntimeError, match="permission denied"):
             backend.ensure_schemas_for_models({"analytics.a", "staging.raw"})
+
+
+class _FakeNamingAdapter(DatabaseAdapter):
+    """Minimal adapter stub exercising the real, unoverridden
+    ``DatabaseAdapter.apply_naming`` every concrete adapter (DuckDB,
+    PostgreSQL, Snowflake, BigQuery) inherits unchanged -- lets
+    ``_model_data_schema`` be tested against each adapter's characteristic
+    physical-name shape (two-part ``schema.table`` for DuckDB/PostgreSQL,
+    three-part ``database.schema.table`` for Snowflake/BigQuery) without
+    needing each adapter's real driver installed or a live connection."""
+
+    REQUIRED_FIELDS = ["type"]
+
+    def get_default_dialect(self) -> str:
+        return "duckdb"
+
+    def get_supported_materializations(self) -> list[MaterializationType]:
+        return [MaterializationType.TABLE, MaterializationType.VIEW]
+
+    def connect(self) -> None:
+        pass
+
+    def disconnect(self) -> None:
+        pass
+
+    def execute_query(self, query: str) -> Any:
+        return None
+
+    def create_table(self, table_name: str, query: str, metadata: Any = None) -> None:
+        pass
+
+    def create_view(self, view_name: str, query: str, metadata: Any = None) -> None:
+        pass
+
+    def table_exists(self, table_name: str) -> bool:
+        return False
+
+    def drop_table(self, table_name: str) -> None:
+        pass
+
+    def get_table_info(self, table_name: str) -> dict[str, Any]:
+        return {"row_count": 0}
+
+    def describe_query_schema(self, sql_query: str) -> list[dict[str, Any]]:
+        return []
+
+    def add_column(self, table_name: str, column: dict[str, Any]) -> None:
+        pass
+
+    def drop_column(self, table_name: str, column_name: str) -> None:
+        pass
+
+    def create_function(self, function_name: str, function_sql: str, metadata: Any = None) -> None:
+        pass
+
+    def function_exists(self, function_name: str, signature: str | None = None) -> bool:
+        return False
+
+    def drop_function(self, function_name: str) -> None:
+        pass
+
+
+class TestModelDataSchemaExtraction:
+    """Code-review fix (finding #2): ``_model_data_schema`` must correctly
+    extract just the schema component regardless of whether
+    ``apply_naming`` returns a two-part (``schema.table`` -- DuckDB,
+    PostgreSQL) or three-part (``database.schema.table`` -- Snowflake,
+    BigQuery) physical name.
+
+    The old implementation did ``physical.rpartition(".")`` and used
+    everything left of the last dot as the schema. For a three-part name
+    that returns ``database.schema`` (not just ``schema``), producing a
+    wrong/invalid ``<schema>_STATE`` name for Snowflake/BigQuery. The fix
+    takes the second-to-last dot-separated part instead -- the same
+    convention ``apply_naming`` itself already uses to decide which part
+    gets ``naming.schema_prefix`` (see ``t4t/adapters/base/core.py``)."""
+
+    @pytest.mark.parametrize(
+        ("adapter_type", "model_name", "expected_schema"),
+        [
+            # Two-part physical names (DuckDB, PostgreSQL): schema.table.
+            ("duckdb", "analytics.orders", "analytics"),
+            ("postgresql", "analytics.orders", "analytics"),
+            # Three-part physical names (Snowflake, BigQuery):
+            # database.schema.table -- only "schema" must be extracted,
+            # not the old "database.schema" bug.
+            ("snowflake", "my_db.analytics.orders", "analytics"),
+            ("bigquery", "my_project.analytics.orders", "analytics"),
+        ],
+    )
+    def test_extracts_schema_for_two_and_three_part_physical_names(
+        self, adapter_type: str, model_name: str, expected_schema: str
+    ) -> None:
+        adapter = _FakeNamingAdapter({"type": adapter_type})
+        assert _model_data_schema(adapter, model_name) == expected_schema
+
+    @pytest.mark.parametrize(
+        ("adapter_type", "model_name"),
+        [
+            ("duckdb", "analytics.orders"),
+            ("postgresql", "analytics.orders"),
+            ("snowflake", "my_db.analytics.orders"),
+            ("bigquery", "my_project.analytics.orders"),
+        ],
+    )
+    def test_extracts_schema_with_naming_prefix_applied(
+        self, adapter_type: str, model_name: str
+    ) -> None:
+        """The schema_prefix must land on the extracted schema (e.g.
+        ``dev_analytics``), for both two-part and three-part physical
+        names -- confirming the fix reuses `apply_naming`'s own prefixed
+        output rather than re-deriving the schema ad hoc."""
+        adapter = _FakeNamingAdapter(
+            {"type": adapter_type, "_naming_config": {"schema_prefix": "dev_"}}
+        )
+        assert _model_data_schema(adapter, model_name) == "dev_analytics"

--- a/tests/state/test_warehouse_backend.py
+++ b/tests/state/test_warehouse_backend.py
@@ -1,0 +1,190 @@
+"""#20 step 5: WarehouseStateBackend round-tripping the full StateBackend
+Protocol against a real DuckDB connection (file-based, not `:memory:` --
+each call opens its own short-lived connection, so an in-memory database
+would not persist data across calls, unlike a real warehouse)."""
+
+from pathlib import Path
+
+import pytest
+
+from t4t.state.backend import StateBackend
+from t4t.state.fingerprint import StoredFingerprint
+from t4t.state.manifest import NodeResult, RunManifest
+from t4t.state.warehouse_backend import WarehouseStateBackend
+
+
+def _connection_config(db_path: Path, schema: str = "analytics") -> dict:
+    return {"type": "duckdb", "path": str(db_path), "schema": schema}
+
+
+def _manifest(run_id: str) -> RunManifest:
+    return RunManifest(
+        schema_version=2,
+        t4t_version="0.1.0",
+        run_id=run_id,
+        command="run",
+        started_at="2026-01-01T00:00:00+00:00",
+        finished_at="2026-01-01T00:01:00+00:00",
+        project_root="/tmp/project",
+        config_hash=None,
+        vars_hash=None,
+        execution_order=["analytics.a"],
+        nodes=[NodeResult(name="analytics.a", status="success", row_count=1)],
+        functions=[],
+    )
+
+
+class TestWarehouseStateBackendProtocolConformance:
+    def test_satisfies_state_backend_protocol(self, tmp_path: Path) -> None:
+        backend = WarehouseStateBackend(_connection_config(tmp_path / "state.duckdb"))
+        assert isinstance(backend, StateBackend)
+
+
+class TestWarehouseStateBackendRunManifest:
+    def test_append_and_read_latest_roundtrip(self, tmp_path: Path) -> None:
+        backend = WarehouseStateBackend(_connection_config(tmp_path / "state.duckdb"))
+        manifest = _manifest("run-1")
+        backend.append_run(manifest)
+
+        latest = backend.read_latest()
+        assert latest is not None
+        assert latest.run_id == "run-1"
+        assert latest.nodes[0].name == "analytics.a"
+
+    def test_read_latest_returns_most_recently_appended(self, tmp_path: Path) -> None:
+        backend = WarehouseStateBackend(_connection_config(tmp_path / "state.duckdb"))
+        backend.append_run(_manifest("run-1"))
+        backend.append_run(_manifest("run-2"))
+
+        latest = backend.read_latest()
+        assert latest.run_id == "run-2"
+
+    def test_read_latest_no_runs_returns_none(self, tmp_path: Path) -> None:
+        backend = WarehouseStateBackend(_connection_config(tmp_path / "state.duckdb"))
+        assert backend.read_latest() is None
+
+    def test_run_manifest_lands_in_expected_schema_table(self, tmp_path: Path) -> None:
+        """Acceptance criterion 1: querying `<schema>_STATE.t4t_model_state`
+        directly on the actual configured connection returns the expected
+        rows."""
+        import duckdb
+
+        db_path = tmp_path / "state.duckdb"
+        backend = WarehouseStateBackend(_connection_config(db_path, schema="analytics"))
+        backend.append_run(_manifest("run-1"))
+
+        conn = duckdb.connect(str(db_path))
+        try:
+            rows = conn.execute(
+                "SELECT record_type, run_id FROM analytics_STATE.t4t_model_state "
+                "WHERE record_type = 'run'"
+            ).fetchall()
+        finally:
+            conn.close()
+        assert rows == [("run", "run-1")]
+
+
+class TestWarehouseStateBackendFingerprint:
+    def test_save_and_read_fingerprint_roundtrip(self, tmp_path: Path) -> None:
+        backend = WarehouseStateBackend(_connection_config(tmp_path / "state.duckdb"))
+        backend.save_fingerprint(
+            model_name="analytics.orders",
+            sql_hash="sql-1",
+            config_hash="cfg-1",
+            fingerprint="fp-1",
+            fingerprint_spec_version=1,
+        )
+
+        record = backend.read_fingerprint("analytics.orders")
+        assert record is not None
+        assert isinstance(record, StoredFingerprint)
+        assert record.model_name == "analytics.orders"
+        assert record.sql_hash == "sql-1"
+        assert record.config_hash == "cfg-1"
+        assert record.fingerprint == "fp-1"
+        assert record.fingerprint_spec_version == 1
+        assert record.updated_at is not None
+
+    def test_read_fingerprint_missing_model_returns_none(self, tmp_path: Path) -> None:
+        backend = WarehouseStateBackend(_connection_config(tmp_path / "state.duckdb"))
+        assert backend.read_fingerprint("analytics.missing") is None
+
+    def test_fingerprint_routed_to_models_own_schema_not_default(self, tmp_path: Path) -> None:
+        """A model in a different schema than the environment's configured
+        default schema still gets its own `<schema>_STATE` table -- state
+        is per data schema, not per connection default."""
+        import duckdb
+
+        db_path = tmp_path / "state.duckdb"
+        # Default/connection schema is "analytics", but the model itself is
+        # in "staging".
+        backend = WarehouseStateBackend(_connection_config(db_path, schema="analytics"))
+        backend.save_fingerprint("staging.raw_orders", "s1", "c1", "f1", 1)
+
+        conn = duckdb.connect(str(db_path))
+        try:
+            schemas = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT schema_name FROM information_schema.schemata"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        assert "staging_STATE" in schemas
+        assert "analytics_STATE" not in schemas  # never touched -- no run appended
+
+    def test_multiple_models_independent(self, tmp_path: Path) -> None:
+        backend = WarehouseStateBackend(_connection_config(tmp_path / "state.duckdb"))
+        backend.save_fingerprint("analytics.a", "sa", "ca", "fa", 1)
+        backend.save_fingerprint("analytics.b", "sb", "cb", "fb", 1)
+
+        a = backend.read_fingerprint("analytics.a")
+        b = backend.read_fingerprint("analytics.b")
+        assert a.sql_hash == "sa"
+        assert b.sql_hash == "sb"
+
+
+class TestEnsureSchemasForModels:
+    def test_ensure_schemas_creates_state_tables_for_all_touched_schemas(
+        self, tmp_path: Path
+    ) -> None:
+        import duckdb
+
+        db_path = tmp_path / "state.duckdb"
+        backend = WarehouseStateBackend(_connection_config(db_path, schema="analytics"))
+        backend.ensure_schemas_for_models({"analytics.a", "staging.raw"})
+
+        conn = duckdb.connect(str(db_path))
+        try:
+            schemas = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT schema_name FROM information_schema.schemata"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        # Default (connection) schema + both models' schemas.
+        assert {"analytics_STATE", "staging_STATE"} <= schemas
+
+    def test_ensure_schemas_fails_whole_call_on_any_ddl_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from t4t.adapters.duckdb.adapter import DuckDBAdapter
+
+        original = DuckDBAdapter.ensure_state_table
+        call_log: list[str] = []
+
+        def _flaky_ensure(self, data_schema: str) -> None:
+            call_log.append(data_schema)
+            if data_schema == "staging_STATE" or data_schema == "staging":
+                raise RuntimeError("permission denied")
+            return original(self, data_schema)
+
+        monkeypatch.setattr(DuckDBAdapter, "ensure_state_table", _flaky_ensure)
+
+        db_path = tmp_path / "state.duckdb"
+        backend = WarehouseStateBackend(_connection_config(db_path, schema="analytics"))
+        with pytest.raises(RuntimeError, match="permission denied"):
+            backend.ensure_schemas_for_models({"analytics.a", "staging.raw"})


### PR DESCRIPTION
## Summary

Implements #20: a pluggable `StateBackend` for run manifests + fingerprints, with a warehouse-table backend (`environments.<env>.state.backend = "warehouse"`) alongside the existing local-disk one (`"local"`, default, unchanged).

- One shared `<schema>_STATE.t4t_model_state` table per *data* schema (not per model table), holding both run-manifest rows and per-model fingerprint rows via a `record_type` discriminator.
- Hand-written per-adapter DDL (no sqlglot transpilation for this system SQL): PostgreSQL/Snowflake use `GENERATED ALWAYS AS IDENTITY`; DuckDB uses `CREATE SEQUENCE` + `DEFAULT nextval(...)` (confirmed empirically that `IDENTITY` is unsupported on DuckDB); BigQuery falls back to a `written_at` wall-clock column (no identity/sequence mechanism exists there) -- a documented limitation, not solved further.
- Missing `CREATE SCHEMA`/`CREATE TABLE` permission fails the run with the literal DDL text (`StateTableDDLError`), not a raw traceback -- and a run touching multiple data schemas fails as a whole if *any* schema's DDL fails, via `WarehouseStateBackend.ensure_schemas_for_models()` pre-creating every touched schema before any writes happen.
- No data migration between `local`/`warehouse` -- switching backends starts fresh, fail-open on missing baseline, same philosophy as #13's `fingerprint_spec_version` mismatch handling.
- `create_state_backend()` (`t4t/state/factory.py`) is now the single place `LocalStateBackend`/`WarehouseStateBackend` get selected; wired into `t4t/executor.py` and `t4t/state/retry.py`.

## Implementation steps (from the issue)

1. ✅ Confirmed #13 merged; read the actual `StateBackend` Protocol shape from `t4t/state/backend.py` and `t4t/engine/fingerprint.py` before designing anything.
2. ✅ Designed `t4t_model_state`: run-manifest fields (`run_id`, `manifest_json`) + fingerprint fields (`model_name`, `sql_hash`, `config_hash`, `fingerprint`, `fingerprint_spec_version`) + `record_type` discriminator + ordering column, reviewed against the full widened Protocol.
3. ✅ Per-adapter DDL implemented for all 4 adapters. **DuckDB verified against a real connection** (`tests/adapters/duckdb/test_state_table.py`), including confirming `GENERATED ALWAYS AS IDENTITY` really is rejected. **PostgreSQL/Snowflake/BigQuery DDL is written against documented syntax but not run against a live connection** -- none available in this environment.
4. ✅ Permission-denied path: `StateTableDDLError` carries the literal DDL text; unit-tested with a fake adapter simulating a permission-denied response (`tests/adapters/test_state_table.py`) and end-to-end via the CLI with a monkeypatched DuckDB adapter (`tests/cli/test_warehouse_state_e2e.py`).
5. ✅ `WarehouseStateBackend` implements the full (widened, post-#13) Protocol. Round-tripped against a real (file-based) DuckDB connection: Protocol conformance, `append_run`/`read_latest`, `save_fingerprint`/`read_fingerprint`, schema routing (`tests/state/test_warehouse_backend.py`).
6. ✅ `environments.<env>.state.backend` wired to backend selection at the `_try_persist_run_manifest`/`prepare_retry_select_patterns` construction points, defaulting to `local`. Regression-tested: omitting the config produces a byte-for-byte identical `LocalStateBackend` construction (`tests/state/test_factory.py`), and the real fingerprint e2e subprocess test (#13, local backend) still passes unmodified.
7. ✅ Backend-switch fail-open, both directions, against a real DuckDB connection (`tests/state/test_backend_switch.py`, plus at the full CLI level in the acceptance test).
8. ✅ Ordering test: rows inserted out of wall-clock order still read back by the `id` sequence column, against a real DuckDB connection (`tests/adapters/duckdb/test_state_table.py::test_ordering_by_id_not_insertion_or_timestamp`). Proves ordering-column correctness only, **not** concurrent-writer thread/process-safety, per the issue's explicit scope.
9. ✅ End-to-end acceptance test: real project (`tests/fixtures/warehouse_state_project/`), `CliRunner`, real DuckDB connection, not mocked backend calls (`tests/cli/test_warehouse_state_e2e.py`).
10. ✅ Documentation: `docs/user-guide/state-backends.md` (new), `docs/getting-started/configuration.md` (new "State backend" section), `docs/user-guide/fingerprinting.md` updated for the now-pluggable storage location. `mkdocs build --strict` passes.

## Acceptance criteria (all 5, in `tests/cli/test_warehouse_state_e2e.py`)

1. ✅ `backend = "warehouse"`: after `t4t run --env dev`, querying `<schema>_STATE.t4t_model_state` directly returns the expected run + fingerprint rows.
2. ✅ `backend` omitted: no `wst_STATE` schema is ever created; `last_run.json`/`runs.sqlite` written exactly as before.
3. ✅ Missing `CREATE SCHEMA` permission (simulated by monkeypatching DuckDB's DDL execution): the run fails with the literal DDL text, not a raw traceback.
4. ✅ Switching `local` -> `warehouse` between two real CLI runs: the local run never touches the warehouse state table; the first warehouse run afterwards has exactly one run row (no crash, no misread).
5. ✅ Rows inserted out of wall-clock order (sequential calls, not real concurrent processes -- explicitly out of scope): `read_latest` deterministically returns by the ordering column.

## What I could not verify

I have DuckDB available locally and used it extensively (both direct adapter tests and full CLI end-to-end runs). **I do not have live PostgreSQL, Snowflake, or BigQuery credentials in this environment.** Their DDL/DML (`t4t/adapters/postgresql/adapter.py`, `t4t/adapters/snowflake/adapter.py`, `t4t/adapters/bigquery/adapter.py`) is written against documented syntax (`GENERATED ALWAYS AS IDENTITY` for Postgres/Snowflake, BigQuery's `CREATE SCHEMA` dataset-alias syntax and named query parameters) and passes `ruff`/imports cleanly, but has **not** been run against a real connection. This matches the issue's own caveat about Snowflake/PostgreSQL's `IDENTITY` support being asserted from documentation, not independently tested during refinement -- that gap is not fully closed by this PR for those three adapters specifically.

## Test suite / lint

- `uv run pytest -q`: **1598 passed, 2 failed, 30 errors, 26 skipped** -- the failures/errors are 100% pre-existing (Snowflake connector not installed in this environment; confirmed identical on `main` via `git stash`), unrelated to this change.
- `uv run ruff check` / `uv run ruff format --check`: clean on every file this PR touches (a handful of pre-existing, unrelated findings remain in `examples/metadata_detection_examples.py`, not modified here).
- `uv run mkdocs build --strict`: passes.

Closes #20
