### PR TITLE
Selection: definition:changed, run:failed, graph modifiers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ Welcome to the Tee for Transform (t4t) documentation. t4t is a powerful Python f
 ### 📖 User Guide
 - [Overview](user-guide/overview.md) - Core concepts and architecture
 - [CLI Reference](user-guide/cli-reference.md) - Complete CLI commands and options reference
+- [Model Selection](user-guide/selection.md) - `--select`/`--exclude` syntax, `definition:changed`, `run:failed`, graph modifiers
+- [Fingerprinting](user-guide/fingerprinting.md) - How t4t detects model definition changes
 - [Execution Engine](user-guide/execution-engine.md) - Running SQL models
 - [Functions](user-guide/functions.md) - User-Defined Functions (UDFs)
 - [Seeds](user-guide/seeds.md) - Loading static data files (CSV, JSON, TSV)

--- a/docs/getting-started/dbt-users-guide.md
+++ b/docs/getting-started/dbt-users-guide.md
@@ -25,6 +25,9 @@ This guide helps dbt users understand t4t by mapping familiar dbt concepts to th
 | **Macros** | **UDFs / Python functions** | SQL macros become SQL UDFs; complex macros become Python functions |
 | **Tests (singular/generic)** | **`@test` decorator / SQL tests** | Python `@test` functions or SQL files in `tests/` |
 | **Tags** | **Tags** | Similar tag-based model selection |
+| **`--select`/`--exclude` combining** (space = union, comma = intersection) | **Same syntax** | t4t implements dbt's selector-combination algebra exactly — `--select a --select b` unions, `--select "a,b"` intersects |
+| **`state:modified`** (dbt State) | **`definition:changed`** | Deliberately not called `state:*` — narrower than dbt State (definition only, no freshness/clone); see [Model Selection](../user-guide/selection.md) |
+| **`+model`/`model+`** (graph operators) | **Same syntax** | Leading `+` = upstream, trailing `+` = downstream |
 | **Hooks** | **N/A (yet)** | Not currently supported |
 | **Snapshots** | **SCD2 materialization** | Set `"materialization": "scd2"` in model metadata — no separate artifact type or command needed |
 | **Exposures** | **N/A (yet)** | Not currently supported |
@@ -294,4 +297,5 @@ SELECT * FROM orders WHERE total < 0
 - [dbt Import Guide](../user-guide/dbt-import.md) — Detailed import instructions
 - [dbt Import Limitations](../user-guide/dbt-import-limitations.md) — Known limitations
 - [Data Quality Tests](../user-guide/data-quality-tests.md) — Testing in t4t
+- [Model Selection](../user-guide/selection.md) — `--select`/`--exclude` syntax, including dbt's own union/intersection algebra and `definition:changed`/`run:failed`
 - [CLI Reference](../user-guide/cli-reference.md) — Complete command reference

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -38,6 +38,16 @@ Selection patterns support:
 - Wildcards: `--select my_*` or `--select *users*`
 - Tags: `--select tag:nightly` or `--select tag:production`
 - Multiple patterns: `--select my_model --select tag:analytics`
+- Definition state: `--select definition:changed` — models whose definition changed vs. the stored baseline
+- Run state: `--select run:failed` — models that failed in the last run (`--retry` is sugar for `--select run:failed+`)
+- Graph modifiers: `+my_model` (upstream), `my_model+` (downstream), `+my_model+` (both)
+- Intersection (AND): comma, no spaces — `--select "definition:changed,tag:nightly"`
+
+Repeated `--select` flags OR together (union); a comma within one value ANDs
+together (intersection) — this matches dbt's own selector-combination
+syntax exactly. See the [Model Selection guide](selection.md) for the full
+reference, including `definition:changed`/`run:failed`/`--retry` and how
+graph modifiers interact with comma groups.
 
 ## Commands
 
@@ -239,8 +249,9 @@ t4t run <project_folder> [options]
 **Options:**
 - `-v, --verbose` - Enable verbose output
 - `--vars <JSON>` - Variables to pass to models (JSON format)
-- `-s, --select <pattern>` - Select models by pattern (can be used multiple times)
+- `-s, --select <pattern>` - Select models by pattern (can be used multiple times) — see [Model Selection](selection.md) for the full syntax (`definition:changed`, `run:failed`, graph modifiers, AND/OR combining)
 - `-e, --exclude <pattern>` - Exclude models by pattern (can be used multiple times)
+- `--retry` - Re-run models that failed or were skipped downstream in the last run; sugar for `--select run:failed+`. Cannot be combined with `--select`.
 - `--auto-resolve-level-conflicts` - When generating lookups, resolve duplicate hierarchy level names as `<dimension>_<level>` (default: on)
 
 **Examples:**
@@ -262,6 +273,12 @@ t4t run ./my_project --exclude tag:test
 
 # Combine selection and exclusion
 t4t run ./my_project --select my_model --exclude tag:deprecated
+
+# Run only models whose definition changed, plus their downstream dependents
+t4t run ./my_project --select definition:changed+
+
+# Retry only what failed (or was skipped downstream) last run
+t4t run ./my_project --retry
 ```
 
 **What it does:**
@@ -301,8 +318,9 @@ t4t build <project_folder> [options]
 **Options:**
 - `-v, --verbose` - Enable verbose output
 - `--vars <JSON>` - Variables to pass to models (JSON format)
-- `-s, --select <pattern>` - Select models by pattern (can be used multiple times)
+- `-s, --select <pattern>` - Select models by pattern (can be used multiple times) — see [Model Selection](selection.md) for the full syntax (`definition:changed`, `run:failed`, graph modifiers, AND/OR combining)
 - `-e, --exclude <pattern>` - Exclude models by pattern (can be used multiple times)
+- `--retry` - Re-run models that failed or were skipped downstream in the last run; sugar for `--select run:failed+`. Cannot be combined with `--select`.
 - `--auto-resolve-level-conflicts` - When generating lookups, resolve duplicate hierarchy level names as `<dimension>_<level>` (default: on)
 
 **Examples:**
@@ -315,6 +333,9 @@ t4t build ./my_project --vars '{"env": "prod"}'
 
 # Build specific models
 t4t build ./my_project --select my_model
+
+# Retry only what failed last build
+t4t build ./my_project --retry
 ```
 
 **What it does:**

--- a/docs/user-guide/fingerprinting.md
+++ b/docs/user-guide/fingerprinting.md
@@ -6,12 +6,13 @@ stable hash of a model's *definition* -- its own source plus, transitively,
 the definitions of everything it depends on -- independent of whether the
 model's last run actually succeeded.
 
-This is a foundational, storage-only feature: t4t does not yet act on
-fingerprints itself (that's `definition:changed` selection, a separate,
-upcoming feature). Today, fingerprinting exists so that feature -- and
-future ones like `t4t plan` and Slim CI -- can be built on a single, shared
-notion of "did this model's definition change" without re-solving change
-detection each time.
+This is a foundational, storage-only feature: fingerprinting itself does
+not decide what to run. That's [`definition:changed` selection](selection.md)
+-- `--select definition:changed`/`definition:changed+` on `t4t run`/`t4t
+build` -- which reads the fingerprints this page describes. Today,
+fingerprinting exists so that feature -- and future ones like `t4t plan`
+and Slim CI -- can be built on a single, shared notion of "did this model's
+definition change" without re-solving change detection each time.
 
 ## What gets hashed
 

--- a/docs/user-guide/selection.md
+++ b/docs/user-guide/selection.md
@@ -1,0 +1,195 @@
+# Model Selection
+
+`t4t run`, `t4t build`, and `t4t test` all accept `-s`/`--select` and
+`-e`/`--exclude` to run a subset of your project instead of everything.
+This page covers the full selection language: name patterns, tags,
+**definition state** (`definition:changed`), **run state**
+(`run:failed`/`--retry`), graph modifiers, and how multiple selectors
+combine.
+
+Name patterns and `tag:` work identically on every command that accepts
+`--select`. `definition:changed`, `run:failed`, and graph modifiers (`+`)
+need a persisted run/fingerprint baseline and the project's dependency
+graph, which today are wired up for `t4t run`/`t4t build` only.
+
+## Quick reference
+
+| Selector | Meaning |
+|---|---|
+| `my_model` | Exact name or glob pattern (`*`, `?`) |
+| `tag:nightly` | Models carrying the `nightly` tag |
+| `definition:changed` | Models whose definition changed vs. the stored baseline (see [Fingerprinting](fingerprinting.md)) |
+| `run:failed` | Models with `status == "failed"` in the last persisted run |
+| `+my_model` | `my_model` and everything it depends on (**upstream**) |
+| `my_model+` | `my_model` and everything that depends on it (**downstream**) |
+| `+my_model+` | Both directions at once |
+| `--select a --select b` | **Union** (OR): matches `a` **or** `b` |
+| `--select "a,b"` | **Intersection** (AND, comma, no spaces): matches `a` **and** `b` |
+
+`--retry` (on `run`/`build`) is sugar for `--select run:failed+`.
+
+## Name patterns and tags
+
+These predate `definition:`/`run:` and work exactly as before:
+
+```bash
+t4t run ./my_project --select my_model
+t4t run ./my_project --select "staging_*"
+t4t run ./my_project --select tag:nightly
+```
+
+A name pattern matches the model's full qualified name (`schema.table`) or
+just the table part, case-insensitively, with `fnmatch`-style wildcards.
+
+Tags currently require a Python model (`@model(tags=[...])`); SQL models'
+`-- metadata: {...}` comment block does not carry `tags` through in the
+current parser.
+
+## `definition:changed`
+
+Selects models whose current **definition fingerprint** differs from the
+fingerprint stored the last time that model was attempted (see
+[Fingerprinting](fingerprinting.md) for exactly what's hashed: a model's own
+SQL/config plus, transitively, everything it depends on).
+
+```bash
+$ t4t run myproject --select definition:changed+
+Filtered to 3 models (from 40 total)
+Filtered execution order: stg_orders -> fct_orders -> customer_ltv
+```
+
+Because the fingerprint chain includes upstream dependencies, a model can
+show as "changed" either because its own source moved, or because
+something it depends on did — `definition:changed` catches both without
+needing `+`. The `+` modifier is for explicitly pulling in *downstream*
+dependents that haven't themselves changed, so they get rebuilt on top of
+the new upstream data.
+
+### No baseline yet (first run)
+
+If a model has never had a fingerprint stored for the current environment,
+it's treated as changed (fail-open) rather than silently skipped:
+
+```bash
+$ t4t run myproject --select definition:changed
+No baseline (env: dev) for 40 model(s) -- treating as changed: ...
+Filtered to 40 models (from 40 total)
+```
+
+This is deliberate: the alternative (select nothing) risks silently
+skipping models a user expects to run on their very first invocation.
+
+### Baseline update semantics
+
+A model's stored fingerprint updates whenever it is **selected and
+execution is attempted** in a run whose manifest gets persisted —
+regardless of whether that attempt **succeeded or failed**. A model that
+fails for a transient reason (e.g. a warehouse timeout) does not keep
+showing up under `definition:changed` on every subsequent run just because
+it failed; use `run:failed` (below) for "retry the broken one," which is
+deliberately a separate, orthogonal selector. Models that were **not**
+attempted (excluded via `--exclude`, or skipped because an upstream
+dependency failed) do not get their baseline updated.
+
+## `run:failed`
+
+Selects models with `status == "failed"` in the most recently persisted run
+manifest for the current environment (`output/<env>/last_run.json`):
+
+```bash
+t4t run myproject --select run:failed
+```
+
+If there is no previous run manifest, or nothing failed in it,
+`run:failed` matches nothing (with a warning), the same "no models matched"
+outcome as any other selector matching zero models.
+
+### `--retry`
+
+```bash
+$ t4t run myproject --retry
+Filtered to 2 models (from 40 total)
+Filtered execution order: fct_orders -> customer_ltv
+```
+
+`--retry` is sugar for `--select run:failed+` — one implementation, not a
+separate mechanism. It cannot be combined with an explicit `--select`.
+
+## Graph modifiers
+
+A leading `+` expands **upstream** (parents/ancestors); a trailing `+`
+expands **downstream** (children/dependents). Modifiers apply to the
+*whole* selector value, not to an individual comma-separated token inside
+it (see [Combining selectors](#combining-selectors) below) — they are
+stripped off first, the remainder is evaluated, and the modifier expands
+*that result*.
+
+| Pattern | Meaning |
+|---|---|
+| `+definition:changed` | Upstream of every changed model |
+| `definition:changed+` | Downstream of every changed model |
+| `run:failed` | Only models that failed last run |
+| `run:failed+` | Failed models + their downstream (what `--retry` uses) |
+| `+run:failed` | Upstream of failed models |
+| `+my_model+` | Both directions at once |
+
+Modifiers work the same way for `t4t run`, `t4t build`, and combined with
+`definition:`/`run:` or a comma AND-group -- e.g.
+`"definition:changed,tag:nightly+"` first computes the changed-and-nightly
+intersection, *then* expands downstream from that result.
+
+## Combining selectors
+
+t4t implements **dbt's own selector-combination algebra exactly** — this is
+deliberate parity, not a superficial similarity, so if you already know
+dbt's `--select` syntax, it works the same way in t4t:
+
+- **Space (repeated `--select`) = union (OR).** A model is selected if it
+  matches *any* of the values you passed:
+
+  ```bash
+  # union: matches the changed model(s) OR anything tagged nightly
+  t4t run myproject --select definition:changed --select tag:nightly
+  ```
+
+- **Comma within *one* `--select` value (no spaces) = intersection (AND).**
+  A model must satisfy *every* comma-separated condition:
+
+  ```bash
+  # intersection: only models that are both changed AND tagged nightly
+  t4t run myproject --select "definition:changed,tag:nightly"
+  ```
+
+Intersection works uniformly across every selector type — name patterns,
+`tag:`, `definition:`, `run:` — you can mix them freely inside one
+comma-group: `--select "definition:changed,tag:nightly,my_model*"`.
+
+Formally: each `--select`/`--exclude` value parses into one **AND-group**
+of atomic conditions (its comma-separated tokens); the set of values from
+repeated flags **OR**s across those groups. A single, no-comma value (e.g.
+`--select my_model`) is the degenerate one-condition case of the same
+structure — today's plain name/tag selection is unchanged.
+
+## `--exclude`
+
+`--exclude` uses the same syntax as `--select` (name patterns, tags,
+`definition:`/`run:`, comma/space algebra, and graph modifiers) and is
+applied *after* selection: a model matching `--select` is dropped if it
+also matches `--exclude`.
+
+## Reserved prefixes
+
+`tag:`, `definition:`, `run:`, and `data:` (reserved for future
+data-freshness selection, not implemented yet) are reserved namespaces —
+avoid naming a model so that its name starts with one of these prefixes
+followed by a colon, as it would be parsed as a virtual selector instead of
+a name pattern.
+
+## Not yet implemented
+
+- **`data:changed`** ("data state" — definition change *or* upstream data
+  went stale) is a deliberately separate, broader concept from
+  `definition:changed`, tracked for a future release.
+- **Remote/shared baselines** (e.g. comparing against a CI/main branch's
+  last successful run) — today's baseline is always the local
+  environment's own last attempt.

--- a/t4t/cli/commands/build.py
+++ b/t4t/cli/commands/build.py
@@ -12,13 +12,15 @@ from importlib.metadata import PackageNotFoundError, version
 import typer
 
 from t4t.cli.context import CommandContext
-from t4t.compiler import CompilationError
 from t4t.engine.connection_manager import ConnectionManager
 from t4t.executor import build_models
 from t4t.parser.output.lookup_generator import generate_lookups
-from t4t.state import prepare_retry_select_patterns
 
 logger = logging.getLogger(__name__)
+
+# #14: --retry is sugar for --select run:failed+ -- see t4t/cli/run.py's
+# identical constant for the full rationale.
+_RETRY_SELECT_PATTERN = "run:failed+"
 
 
 def _t4t_version() -> str:
@@ -126,22 +128,7 @@ def cmd_build(
 
         select_patterns = ctx.select_patterns
         if retry:
-            try:
-                select_patterns = prepare_retry_select_patterns(
-                    str(ctx.project_path),
-                    ctx.config["connection"],
-                    ctx.vars,
-                    ctx.config,
-                    env_name=ctx.env_name,
-                )
-            except ValueError as e:
-                typer.echo(
-                    typer.style("Error: ", fg=typer.colors.RED, bold=True) + str(e),
-                    err=True,
-                )
-                raise typer.Exit(1) from None
-            except CompilationError as e:
-                ctx.handle_error(e)
+            select_patterns = [_RETRY_SELECT_PATTERN]
 
         # Build models with interleaved tests
         results = build_models(

--- a/t4t/cli/commands/run.py
+++ b/t4t/cli/commands/run.py
@@ -10,13 +10,17 @@ from importlib.metadata import PackageNotFoundError, version
 import typer
 
 from t4t.cli.context import CommandContext
-from t4t.compiler import CompilationError
 from t4t.engine.connection_manager import ConnectionManager
 from t4t.executor import execute_models
 from t4t.parser.output.lookup_generator import generate_lookups
-from t4t.state import prepare_retry_select_patterns
 
 logger = logging.getLogger(__name__)
+
+# #14: --retry is sugar for --select run:failed+ -- one implementation
+# (ModelSelector's run:failed atomic condition + trailing-+ downstream
+# modifier), not a second parallel "compute retry set" mechanism. See
+# t4t/cli/selection.py and t4t/state/graph_walk.py.
+_RETRY_SELECT_PATTERN = "run:failed+"
 
 
 def _t4t_version() -> str:
@@ -125,22 +129,7 @@ def cmd_run(
 
         select_patterns = ctx.select_patterns
         if retry:
-            try:
-                select_patterns = prepare_retry_select_patterns(
-                    str(ctx.project_path),
-                    ctx.config["connection"],
-                    ctx.vars,
-                    ctx.config,
-                    env_name=ctx.env_name,
-                )
-            except ValueError as e:
-                typer.echo(
-                    typer.style("Error: ", fg=typer.colors.RED, bold=True) + str(e),
-                    err=True,
-                )
-                raise typer.Exit(1) from None
-            except CompilationError as e:
-                ctx.handle_error(e)
+            select_patterns = [_RETRY_SELECT_PATTERN]
 
         # Inject _naming_config into connection_config so it reaches the executor
         connection_config = ctx.config["connection"]

--- a/t4t/cli/selection.py
+++ b/t4t/cli/selection.py
@@ -38,6 +38,8 @@ Atomic conditions (interchangeable inside any AND-group):
 clear error rather than being silently treated as a name pattern.
 """
 
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
 from fnmatch import fnmatch
@@ -121,9 +123,7 @@ def _name_matches(model_name: str, pattern: str) -> bool:
         fnmatch(parts[-1], pattern) or fnmatch(parts[-1].lower(), pattern.lower())
     ):
         return True
-    if model_name == pattern or model_name.lower() == pattern.lower():
-        return True
-    return False
+    return model_name == pattern or model_name.lower() == pattern.lower()
 
 
 def _has_tag(model_data: dict[str, Any], tag: str) -> bool:
@@ -145,7 +145,7 @@ class NameCondition:
     pattern: str
 
     def matches(
-        self, model_name: str, model_data: dict[str, Any], ctx: _SelectionContext | None
+        self, model_name: str, _model_data: dict[str, Any], _ctx: _SelectionContext | None
     ) -> bool:
         return _name_matches(model_name, self.pattern)
 
@@ -157,7 +157,7 @@ class TagCondition:
     tag: str
 
     def matches(
-        self, model_name: str, model_data: dict[str, Any], ctx: _SelectionContext | None
+        self, _model_name: str, model_data: dict[str, Any], _ctx: _SelectionContext | None
     ) -> bool:
         return _has_tag(model_data, self.tag)
 
@@ -167,7 +167,7 @@ class DefinitionChangedCondition:
     """`definition:changed` atomic condition (#13 fingerprint diff vs baseline)."""
 
     def matches(
-        self, model_name: str, model_data: dict[str, Any], ctx: _SelectionContext | None
+        self, model_name: str, _model_data: dict[str, Any], ctx: _SelectionContext | None
     ) -> bool:
         if ctx is None or ctx.changed_set is None:
             raise SelectionContextError(
@@ -182,7 +182,7 @@ class RunFailedCondition:
     """`run:failed` atomic condition (#18 last persisted run manifest)."""
 
     def matches(
-        self, model_name: str, model_data: dict[str, Any], ctx: _SelectionContext | None
+        self, model_name: str, _model_data: dict[str, Any], ctx: _SelectionContext | None
     ) -> bool:
         if ctx is None or ctx.failed_set is None:
             raise SelectionContextError(
@@ -275,7 +275,7 @@ class ModelSelector:
         select_patterns: list[str] | None = None,
         exclude_patterns: list[str] | None = None,
         *,
-        state_backend: "StateBackend | None" = None,
+        state_backend: StateBackend | None = None,
         env_name: str | None = None,
     ) -> None:
         """
@@ -314,7 +314,7 @@ class ModelSelector:
         self,
         parsed_models: dict[str, Any],
         graph: dict[str, Any] | None = None,
-        state_backend: "StateBackend | None" = None,
+        state_backend: StateBackend | None = None,
     ) -> None:
         """Resolve data-backed conditions (`definition:changed`, `run:failed`)
         and graph modifiers (`+`) against a concrete project.
@@ -328,9 +328,7 @@ class ModelSelector:
         backend = state_backend if state_backend is not None else self.state_backend
         needs_changed = self._uses_condition(DefinitionChangedCondition)
         needs_failed = self._uses_condition(RunFailedCondition)
-        needs_graph = any(
-            g.has_modifier for g in (*self.select_groups, *self.exclude_groups)
-        )
+        needs_graph = any(g.has_modifier for g in (*self.select_groups, *self.exclude_groups))
 
         changed_set: set[str] | None = None
         failed_set: set[str] | None = None
@@ -394,7 +392,9 @@ class ModelSelector:
 
     # -- matching ----------------------------------------------------------
 
-    def _group_matches(self, group: SelectGroup, model_name: str, model_data: dict[str, Any]) -> bool:
+    def _group_matches(
+        self, group: SelectGroup, model_name: str, model_data: dict[str, Any]
+    ) -> bool:
         if group.has_modifier:
             expanded = self._expanded.get(id(group))
             if expanded is None:
@@ -436,12 +436,10 @@ class ModelSelector:
         if not selected:
             return False
 
-        if self.exclude_patterns and self._matches_any_group(
-            self.exclude_groups, model_name, model_data
-        ):
-            return False
-
-        return True
+        return not (
+            self.exclude_patterns
+            and self._matches_any_group(self.exclude_groups, model_name, model_data)
+        )
 
     def filter_models(
         self,
@@ -449,7 +447,7 @@ class ModelSelector:
         execution_order: list[str] | None = None,
         *,
         graph: dict[str, Any] | None = None,
-        state_backend: "StateBackend | None" = None,
+        state_backend: StateBackend | None = None,
     ) -> tuple[dict[str, Any], list[str]]:
         """
         Filter parsed models and execution order based on selection criteria.

--- a/t4t/cli/selection.py
+++ b/t4t/cli/selection.py
@@ -1,137 +1,425 @@
 """
-Model selection utilities for filtering models by name and tags.
+Model selection utilities for filtering models by name, tags, definition
+change, and last-run status.
 
-Supports --select and --exclude flags similar to dbt's selection syntax.
+Supports `--select`/`--exclude` (dbt-compatible selection syntax):
+
+- **Union (OR)**: repeated `--select` flags OR together -- a model is
+  selected if it matches *any* one of them.
+- **Intersection (AND)**: comma-separated tokens *within one* `--select`
+  value (no spaces) AND together -- a model must satisfy *every* token to
+  be selected via that value.
+- **Graph modifiers**: a leading `+` (e.g. `+my_model`) expands to also
+  include everything the match set depends on (upstream); a trailing `+`
+  (e.g. `my_model+`) expands to also include everything that depends on the
+  match set (downstream). Modifiers are stripped from the *whole*
+  `--select` value before the comma-split and apply to the group's result
+  as a whole, never to an individual comma-separated token.
+
+Parsing model (disjunctive normal form -- OR of AND-groups): each
+`--select`/`--exclude` value is one AND-group of atomic conditions
+(comma-separated, no spaces); the list of repeated flags is OR'd across
+groups. A single bare pattern (no comma) is the degenerate one-condition
+group -- today's pre-#14 behavior, unchanged.
+
+Atomic conditions (interchangeable inside any AND-group):
+
+- Plain name pattern (glob, e.g. `stg_orders`, `staging_*`).
+- `tag:<tag>` -- model carries this tag.
+- `definition:changed` -- model's current fingerprint differs from the
+  stored baseline (#13's fingerprint storage; see
+  ``docs/user-guide/fingerprinting.md`` and
+  ``docs/user-guide/selection.md``). Requires a `StateBackend` and the
+  project's dependency graph -- see `ModelSelector.filter_models`.
+- `run:failed` -- model has `status == "failed"` in the last persisted run
+  manifest (#18). Requires a `StateBackend`.
+
+`data:*` is a reserved prefix for #19 (not implemented yet) and raises a
+clear error rather than being silently treated as a name pattern.
 """
 
+import logging
+from dataclasses import dataclass
 from fnmatch import fnmatch
-from typing import Any
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from t4t.state.backend import StateBackend
+
+logger = logging.getLogger(__name__)
+
+_TEST_NODE_PREFIX = "test:"
+
+# Namespace prefixes reserved for virtual selectors -- model names should
+# not rely on these prefixes (same caveat that already applied to `tag:`).
+_DEFINITION_PREFIX = "definition:"
+_RUN_PREFIX = "run:"
+_DATA_PREFIX = "data:"  # reserved for #19, not implemented
+
+
+class SelectionError(ValueError):
+    """Base class for `--select`/`--exclude` errors surfaced to the CLI.
+
+    Subclasses `ValueError` so existing `except ValueError` / catch-all
+    `except Exception` handling in the CLI commands (`run.py`/`build.py`)
+    already reports these as clean user-facing errors without extra wiring.
+    """
+
+
+class SelectionParseError(SelectionError):
+    """A `--select`/`--exclude` value could not be parsed."""
+
+
+class SelectionContextError(SelectionError):
+    """A parsed selector needs data (a `StateBackend`, a dependency graph)
+    that wasn't provided -- e.g. `definition:changed` without a
+    `state_backend`, or a graph modifier (`+`) without a `graph`."""
+
+
+# --------------------------------------------------------------------------
+# Atomic conditions
+# --------------------------------------------------------------------------
+
+
+class _SelectionContext:
+    """Precomputed, per-`ModelSelector` data that atomic conditions read.
+
+    Built once (see `ModelSelector.prepare`) from a `StateBackend` +
+    dependency graph + the full set of parsed models -- never recomputed
+    per model.
+    """
+
+    def __init__(
+        self,
+        changed_set: set[str] | None = None,
+        failed_set: set[str] | None = None,
+    ) -> None:
+        self.changed_set = changed_set
+        self.failed_set = failed_set
+
+
+class Condition(Protocol):
+    """An atomic, composable selection condition."""
+
+    def matches(
+        self, model_name: str, model_data: dict[str, Any], ctx: _SelectionContext | None
+    ) -> bool: ...
+
+
+def _name_matches(model_name: str, pattern: str) -> bool:
+    """Match a single model name against a single glob pattern.
+
+    Same semantics as pre-#14's `_matches_name`, applied to one pattern at
+    a time: full-name match, last-dot-segment match (so `--select
+    my_table` matches `schema.my_table`), and case-insensitive fallback for
+    both, all supporting `fnmatch`-style wildcards.
+    """
+    if fnmatch(model_name, pattern) or fnmatch(model_name.lower(), pattern.lower()):
+        return True
+    parts = model_name.split(".")
+    if len(parts) > 1 and (
+        fnmatch(parts[-1], pattern) or fnmatch(parts[-1].lower(), pattern.lower())
+    ):
+        return True
+    if model_name == pattern or model_name.lower() == pattern.lower():
+        return True
+    return False
+
+
+def _has_tag(model_data: dict[str, Any], tag: str) -> bool:
+    """Check if model has the specified tag (case-insensitive)."""
+    try:
+        metadata = model_data.get("model_metadata", {})
+        tags = metadata.get("metadata", {}).get("tags", [])
+        if not tags:
+            return False
+        return any(t.lower() == tag.lower() for t in tags)
+    except (AttributeError, TypeError):
+        return False
+
+
+@dataclass(frozen=True)
+class NameCondition:
+    """Plain name-pattern atomic condition (glob, exact, or table-only)."""
+
+    pattern: str
+
+    def matches(
+        self, model_name: str, model_data: dict[str, Any], ctx: _SelectionContext | None
+    ) -> bool:
+        return _name_matches(model_name, self.pattern)
+
+
+@dataclass(frozen=True)
+class TagCondition:
+    """`tag:<tag>` atomic condition."""
+
+    tag: str
+
+    def matches(
+        self, model_name: str, model_data: dict[str, Any], ctx: _SelectionContext | None
+    ) -> bool:
+        return _has_tag(model_data, self.tag)
+
+
+@dataclass(frozen=True)
+class DefinitionChangedCondition:
+    """`definition:changed` atomic condition (#13 fingerprint diff vs baseline)."""
+
+    def matches(
+        self, model_name: str, model_data: dict[str, Any], ctx: _SelectionContext | None
+    ) -> bool:
+        if ctx is None or ctx.changed_set is None:
+            raise SelectionContextError(
+                "'definition:changed' requires a StateBackend and dependency graph "
+                "(pass state_backend/graph to ModelSelector.filter_models())."
+            )
+        return model_name in ctx.changed_set
+
+
+@dataclass(frozen=True)
+class RunFailedCondition:
+    """`run:failed` atomic condition (#18 last persisted run manifest)."""
+
+    def matches(
+        self, model_name: str, model_data: dict[str, Any], ctx: _SelectionContext | None
+    ) -> bool:
+        if ctx is None or ctx.failed_set is None:
+            raise SelectionContextError(
+                "'run:failed' requires a StateBackend "
+                "(pass state_backend to ModelSelector.filter_models())."
+            )
+        return model_name in ctx.failed_set
+
+
+# --------------------------------------------------------------------------
+# Parsing: modifiers, comma AND-groups, atomic conditions
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class SelectGroup:
+    """One AND-group parsed from a single `--select`/`--exclude` value."""
+
+    conditions: list[Condition]
+    upstream: bool = False
+    downstream: bool = False
+    raw: str = ""
+
+    @property
+    def has_modifier(self) -> bool:
+        return self.upstream or self.downstream
+
+
+def _strip_modifiers(value: str) -> tuple[str, bool, bool]:
+    """Strip a leading `+` (upstream) and/or trailing `+` (downstream) off
+    the *whole* selector value, before any comma-split. Returns (remainder,
+    upstream, downstream)."""
+    upstream = False
+    downstream = False
+    remainder = value
+    if remainder.startswith("+"):
+        upstream = True
+        remainder = remainder[1:]
+    if remainder.endswith("+"):
+        downstream = True
+        remainder = remainder[:-1]
+    return remainder, upstream, downstream
+
+
+def _parse_atomic_condition(token: str) -> Condition:
+    if token.startswith("tag:"):
+        return TagCondition(token[len("tag:") :])
+    if token.startswith(_DEFINITION_PREFIX):
+        value = token[len(_DEFINITION_PREFIX) :]
+        if value != "changed":
+            raise SelectionParseError(
+                f"Unsupported selector {token!r}: only 'definition:changed' is implemented."
+            )
+        return DefinitionChangedCondition()
+    if token.startswith(_RUN_PREFIX):
+        value = token[len(_RUN_PREFIX) :]
+        if value != "failed":
+            raise SelectionParseError(
+                f"Unsupported selector {token!r}: only 'run:failed' is implemented."
+            )
+        return RunFailedCondition()
+    if token.startswith(_DATA_PREFIX):
+        raise SelectionParseError(
+            f"'data:' selectors ({token!r}) are reserved for data-state selection "
+            "(#19) and not implemented yet."
+        )
+    return NameCondition(token)
+
+
+def _parse_group(value: str) -> SelectGroup:
+    remainder, upstream, downstream = _strip_modifiers(value)
+    tokens = [t for t in remainder.split(",") if t]
+    if not tokens:
+        raise SelectionParseError(f"Empty selector: {value!r}")
+    conditions = [_parse_atomic_condition(t) for t in tokens]
+    return SelectGroup(conditions=conditions, upstream=upstream, downstream=downstream, raw=value)
+
+
+# --------------------------------------------------------------------------
+# ModelSelector
+# --------------------------------------------------------------------------
 
 
 class ModelSelector:
-    """Selects models based on name patterns and tags."""
+    """Selects models based on name patterns, tags, definition change, and
+    last-run status, combined via dbt-compatible OR-of-AND-groups."""
 
     def __init__(
-        self, select_patterns: list[str] | None = None, exclude_patterns: list[str] | None = None
+        self,
+        select_patterns: list[str] | None = None,
+        exclude_patterns: list[str] | None = None,
+        *,
+        state_backend: "StateBackend | None" = None,
+        env_name: str | None = None,
     ) -> None:
         """
         Initialize model selector.
 
         Args:
-            select_patterns: List of selection patterns (e.g., ["my_model", "tag:nightly"])
-            exclude_patterns: List of exclusion patterns (e.g., ["deprecated", "tag:test"])
+            select_patterns: List of `--select` values (e.g.
+                `["my_model", "tag:nightly", "definition:changed,tag:nightly+"]`).
+                Repeated values OR together; comma-separated tokens *within*
+                one value AND together (dbt-compatible).
+            exclude_patterns: List of `--exclude` values, same syntax.
+            state_backend: `StateBackend` used to resolve `definition:changed`
+                and `run:failed`. Can also be supplied later via
+                `filter_models(..., state_backend=...)`.
+            env_name: Environment name, used only for log messages (e.g.
+                "no baseline for environment 'dev'").
         """
         self.select_patterns = select_patterns or []
         self.exclude_patterns = exclude_patterns or []
+        self.state_backend = state_backend
+        self.env_name = env_name
 
-        # Parse patterns into name patterns and tag patterns
-        self.select_names: list[str] = []
-        self.select_tags: list[str] = []
-        self.exclude_names: list[str] = []
-        self.exclude_tags: list[str] = []
+        self.select_groups: list[SelectGroup] = [_parse_group(p) for p in self.select_patterns]
+        self.exclude_groups: list[SelectGroup] = [_parse_group(p) for p in self.exclude_patterns]
 
-        self._parse_patterns()
+        self._ctx: _SelectionContext | None = None
+        # Populated by `prepare()` only for groups that use a graph modifier
+        # (`+`) -- those need the full-project match set expanded via graph
+        # traversal, which can't be evaluated per-model. Keyed by id(group).
+        self._expanded: dict[int, set[str]] = {}
+        self._prepared = False
 
-    def _parse_patterns(self) -> None:
-        """Parse selection and exclusion patterns into name and tag categories."""
-        # Parse select patterns
-        for pattern in self.select_patterns:
-            if pattern.startswith("tag:"):
-                tag = pattern[4:]  # Remove "tag:" prefix
-                self.select_tags.append(tag)
-            else:
-                self.select_names.append(pattern)
+    # -- preparation (data-backed conditions + graph modifiers) ----------
 
-        # Parse exclude patterns
-        for pattern in self.exclude_patterns:
-            if pattern.startswith("tag:"):
-                tag = pattern[4:]  # Remove "tag:" prefix
-                self.exclude_tags.append(tag)
-            else:
-                self.exclude_names.append(pattern)
+    def prepare(
+        self,
+        parsed_models: dict[str, Any],
+        graph: dict[str, Any] | None = None,
+        state_backend: "StateBackend | None" = None,
+    ) -> None:
+        """Resolve data-backed conditions (`definition:changed`, `run:failed`)
+        and graph modifiers (`+`) against a concrete project.
 
-    def _matches_name(self, model_name: str, patterns: list[str]) -> bool:
+        `parsed_models` must be the project's *full*, unfiltered set (graph
+        modifiers expand from the true dependency graph, not from an
+        already-selected subset). Safe to call more than once (e.g. if
+        `filter_models` is called again); each call recomputes from
+        scratch.
         """
-        Check if model name matches any of the patterns.
+        backend = state_backend if state_backend is not None else self.state_backend
+        needs_changed = self._uses_condition(DefinitionChangedCondition)
+        needs_failed = self._uses_condition(RunFailedCondition)
+        needs_graph = any(
+            g.has_modifier for g in (*self.select_groups, *self.exclude_groups)
+        )
 
-        Supports exact match and wildcard patterns (*, ?).
+        changed_set: set[str] | None = None
+        failed_set: set[str] | None = None
 
-        Args:
-            model_name: Full table name (e.g., "schema.table")
-            patterns: List of patterns to match against
+        if needs_changed:
+            if backend is None:
+                raise SelectionContextError(
+                    "'definition:changed' requires a StateBackend "
+                    "(pass state_backend to ModelSelector.filter_models())."
+                )
+            changed_set = _compute_changed_set(parsed_models, graph or {}, backend, self.env_name)
 
-        Returns:
-            True if model_name matches any pattern
-        """
-        if not patterns:
-            return False
+        if needs_failed:
+            if backend is None:
+                raise SelectionContextError(
+                    "'run:failed' requires a StateBackend "
+                    "(pass state_backend to ModelSelector.filter_models())."
+                )
+            failed_set = _compute_failed_set(backend)
 
-        for pattern in patterns:
-            # Support wildcard matching
-            if fnmatch(model_name, pattern) or fnmatch(model_name.lower(), pattern.lower()):
-                return True
-            # Also support partial matches (e.g., "schema.table" matches "table"):
-            # check if the pattern matches just the table name part
-            parts = model_name.split(".")
-            if len(parts) > 1 and (
-                fnmatch(parts[-1], pattern) or fnmatch(parts[-1].lower(), pattern.lower())
-            ):
-                return True
-            # Exact match
-            if model_name == pattern or model_name.lower() == pattern.lower():
-                return True
+        self._ctx = _SelectionContext(changed_set=changed_set, failed_set=failed_set)
 
+        self._expanded = {}
+        if needs_graph:
+            if graph is None:
+                raise SelectionContextError(
+                    "A graph modifier ('+') requires the project's dependency graph "
+                    "(pass graph to ModelSelector.filter_models())."
+                )
+            universe = list(parsed_models.keys())
+            for group in (*self.select_groups, *self.exclude_groups):
+                if not group.has_modifier:
+                    continue
+                base = {
+                    name
+                    for name in universe
+                    if all(
+                        cond.matches(name, parsed_models[name], self._ctx)
+                        for cond in group.conditions
+                    )
+                }
+                expanded = set(base)
+                if group.upstream:
+                    from t4t.state.graph_walk import transitive_upstream
+
+                    expanded |= transitive_upstream(graph, base)
+                if group.downstream:
+                    from t4t.state.graph_walk import transitive_downstream
+
+                    expanded |= transitive_downstream(graph, base)
+                self._expanded[id(group)] = expanded
+
+        self._prepared = True
+
+    def _uses_condition(self, condition_type: type) -> bool:
+        for group in (*self.select_groups, *self.exclude_groups):
+            for cond in group.conditions:
+                if isinstance(cond, condition_type):
+                    return True
         return False
 
-    def _has_tag(self, model_data: dict[str, Any], tag: str) -> bool:
-        """
-        Check if model has the specified tag.
+    # -- matching ----------------------------------------------------------
 
-        Tags are stored in model_metadata.metadata.tags
+    def _group_matches(self, group: SelectGroup, model_name: str, model_data: dict[str, Any]) -> bool:
+        if group.has_modifier:
+            expanded = self._expanded.get(id(group))
+            if expanded is None:
+                raise SelectionContextError(
+                    f"Selector {group.raw!r} uses a graph modifier ('+') and requires "
+                    "ModelSelector.prepare()/filter_models() to be called with a "
+                    "dependency graph before is_selected()."
+                )
+            return model_name in expanded
+        return all(cond.matches(model_name, model_data, self._ctx) for cond in group.conditions)
 
-        Args:
-            model_data: Parsed model data
-            tag: Tag to check for
-
-        Returns:
-            True if model has the tag
-        """
-        try:
-            metadata = model_data.get("model_metadata", {})
-            tags = metadata.get("metadata", {}).get("tags", [])
-
-            if not tags:
-                return False
-
-            # Check if tag is in the list (case-insensitive)
-            return any(t.lower() == tag.lower() for t in tags)
-        except (AttributeError, TypeError):
-            return False
-
-    def _matches_tags(self, model_data: dict[str, Any], tags: list[str]) -> bool:
-        """
-        Check if model matches any of the specified tags.
-
-        Args:
-            model_data: Parsed model data
-            tags: List of tags to check for
-
-        Returns:
-            True if model has any of the tags
-        """
-        if not tags:
-            return False
-
-        return any(self._has_tag(model_data, tag) for tag in tags)
+    def _matches_any_group(
+        self, groups: list[SelectGroup], model_name: str, model_data: dict[str, Any]
+    ) -> bool:
+        return any(self._group_matches(group, model_name, model_data) for group in groups)
 
     def is_selected(self, model_name: str, model_data: dict[str, Any]) -> bool:
         """
         Determine if a model should be selected based on selection and exclusion criteria.
 
         Selection logic:
-        1. If no select patterns, all models are selected (unless excluded)
-        2. Model must match at least one select pattern (name or tag)
-        3. Model must not match any exclude pattern (name or tag)
+        1. If no select patterns, all models are selected (unless excluded).
+        2. Model must match at least one select group (OR across groups; a
+           group matches only if the model satisfies every condition in it, AND).
+        3. Model must not match any exclude group.
 
         Args:
             model_name: Full table name (e.g., "schema.table")
@@ -140,76 +428,112 @@ class ModelSelector:
         Returns:
             True if model should be included, False otherwise
         """
-        # If no select patterns, all models are selected by default
         if not self.select_patterns:
-            # Only check exclusion
-            if self.exclude_patterns:
-                return not self._is_excluded(model_name, model_data)
-            return True
+            selected = True
+        else:
+            selected = self._matches_any_group(self.select_groups, model_name, model_data)
 
-        # Check if model matches selection criteria
-        matches_select = False
-
-        # Check name patterns
-        if self.select_names:
-            matches_select = matches_select or self._matches_name(model_name, self.select_names)
-
-        # Check tag patterns
-        if self.select_tags:
-            matches_select = matches_select or self._matches_tags(model_data, self.select_tags)
-
-        if not matches_select:
+        if not selected:
             return False
 
-        # Check exclusion
-        if self.exclude_patterns:
-            return not self._is_excluded(model_name, model_data)
+        if self.exclude_patterns and self._matches_any_group(
+            self.exclude_groups, model_name, model_data
+        ):
+            return False
 
         return True
 
-    def _is_excluded(self, model_name: str, model_data: dict[str, Any]) -> bool:
-        """
-        Check if model matches exclusion criteria.
-
-        Args:
-            model_name: Full table name
-            model_data: Parsed model data
-
-        Returns:
-            True if model should be excluded
-        """
-        # Excluded when matching a name exclusion or a tag exclusion
-        if self.exclude_names and self._matches_name(model_name, self.exclude_names):
-            return True
-        if self.exclude_tags and self._matches_tags(model_data, self.exclude_tags):  # noqa: SIM103
-            return True
-        return False
-
     def filter_models(
-        self, parsed_models: dict[str, Any], execution_order: list[str] | None = None
+        self,
+        parsed_models: dict[str, Any],
+        execution_order: list[str] | None = None,
+        *,
+        graph: dict[str, Any] | None = None,
+        state_backend: "StateBackend | None" = None,
     ) -> tuple[dict[str, Any], list[str]]:
         """
         Filter parsed models and execution order based on selection criteria.
 
         Args:
-            parsed_models: Dictionary of all parsed models
+            parsed_models: Dictionary of all parsed models. Must be the
+                project's *full*, unfiltered set -- graph modifiers and
+                `definition:changed`'s fingerprint chain both need the true
+                project graph, not an already-narrowed one.
             execution_order: Optional list of model names in execution order
+            graph: Project's dependency graph (`{"dependencies": ...,
+                "dependents": ..., "execution_order": ...}`), required only
+                if any selector uses a graph modifier (`+`) or
+                `definition:changed` (fingerprint chain needs it too).
+            state_backend: `StateBackend`, required only if any selector
+                uses `definition:changed` or `run:failed`. Falls back to the
+                one passed to `__init__`.
 
         Returns:
             Tuple of (filtered_models, filtered_execution_order)
         """
-        filtered_models = {}
-        filtered_order = []
+        self.prepare(parsed_models, graph=graph, state_backend=state_backend)
 
-        # Filter models
+        filtered_models = {}
         for model_name, model_data in parsed_models.items():
             if self.is_selected(model_name, model_data):
                 filtered_models[model_name] = model_data
 
-        # Filter execution order
+        filtered_order = []
         if execution_order:
             for model_name in execution_order:
                 if model_name in filtered_models:
                     filtered_order.append(model_name)
 
         return filtered_models, filtered_order
+
+
+def _compute_changed_set(
+    parsed_models: dict[str, Any],
+    graph: dict[str, Any],
+    state_backend: Any,
+    env_name: str | None,
+) -> set[str]:
+    """Models whose current fingerprint differs from the stored baseline
+    (#13), plus models with no stored baseline at all (fail-open -- treated
+    as changed, per #14's "missing baseline" design decision)."""
+    from t4t.engine.fingerprint import compute_project_fingerprints, read_valid_fingerprint
+
+    current = compute_project_fingerprints(parsed_models, graph)
+
+    changed: set[str] = set()
+    missing: list[str] = []
+    for name, fp in current.items():
+        stored = read_valid_fingerprint(state_backend, name)
+        if stored is None:
+            changed.add(name)
+            missing.append(name)
+        elif stored.fingerprint != fp.fingerprint:
+            changed.add(name)
+
+    if missing:
+        env_desc = f" (env: {env_name})" if env_name else ""
+        logger.warning(
+            "No baseline%s for %d model(s) -- treating as changed: %s",
+            env_desc,
+            len(missing),
+            ", ".join(sorted(missing)),
+            extra={"cli_output": True},
+        )
+
+    return changed
+
+
+def _compute_failed_set(state_backend: Any) -> set[str]:
+    """Model names with `status == "failed"` in the last persisted run manifest."""
+    manifest = state_backend.read_latest()
+    if manifest is None:
+        logger.warning(
+            "'run:failed' matched no models: no previous run manifest found.",
+            extra={"cli_output": True},
+        )
+        return set()
+    return {
+        node.name
+        for node in manifest.nodes
+        if node.status == "failed" and not node.name.startswith(_TEST_NODE_PREFIX)
+    }

--- a/t4t/executor.py
+++ b/t4t/executor.py
@@ -211,12 +211,27 @@ def execute_models(
     filtered_execution_order = None
 
     if select_patterns or exclude_patterns:
-        from .cli.selection import ModelSelector
+        from pathlib import Path
 
-        selector = ModelSelector(select_patterns=select_patterns, exclude_patterns=exclude_patterns)
+        from .cli.selection import ModelSelector
+        from .state import LocalStateBackend
+
+        # Same env-scoped backend _try_persist_run_manifest() constructs
+        # below -- only actually touched (read) if a selector uses
+        # definition:changed/run:failed (see ModelSelector.prepare()).
+        state_backend = LocalStateBackend(Path(project_folder) / "output", env_name=env_name)
+        selector = ModelSelector(
+            select_patterns=select_patterns,
+            exclude_patterns=exclude_patterns,
+            state_backend=state_backend,
+            env_name=env_name,
+        )
         original_count = len(parsed_models)
+        # `parsed_models`/`graph` here are the project's full, unfiltered set
+        # -- required both for definition:changed's fingerprint chain and for
+        # graph modifiers ('+') to expand from the true dependency graph.
         filtered_parsed_models, filtered_execution_order = selector.filter_models(
-            parsed_models, execution_order
+            parsed_models, execution_order, graph=graph, state_backend=state_backend
         )
         filtered_count = len(filtered_parsed_models)
 
@@ -431,6 +446,7 @@ def build_models(
         parsed_models,
         graph,
         execution_order,
+        env_name=env_name,
     )
 
     # Load seeds even if there are no models (seeds should load regardless)

--- a/t4t/executor_helpers/build_helpers.py
+++ b/t4t/executor_helpers/build_helpers.py
@@ -40,6 +40,7 @@ def setup_build_context_from_compile(
     parsed_models: dict[str, Any],
     graph: dict[str, Any],
     execution_order: list[str],
+    env_name: str | None = None,
 ) -> tuple[ProjectParser, dict[str, Any], dict[str, Any], list[str]]:
     """
     Set up build context using compile results (graph and models).
@@ -54,11 +55,26 @@ def setup_build_context_from_compile(
 
     # Apply selection filters if provided
     if select_patterns or exclude_patterns:
-        from t4t.cli.selection import ModelSelector
+        from pathlib import Path
 
-        selector = ModelSelector(select_patterns=select_patterns, exclude_patterns=exclude_patterns)
+        from t4t.cli.selection import ModelSelector
+        from t4t.state import LocalStateBackend
+
+        # Same env-scoped backend build_models()'s _try_persist_run_manifest
+        # call constructs -- only actually touched (read) if a selector uses
+        # definition:changed/run:failed (see ModelSelector.prepare()).
+        state_backend = LocalStateBackend(Path(project_folder) / "output", env_name=env_name)
+        selector = ModelSelector(
+            select_patterns=select_patterns,
+            exclude_patterns=exclude_patterns,
+            state_backend=state_backend,
+            env_name=env_name,
+        )
+        # `parsed_models`/`graph` here are the project's full, unfiltered set
+        # -- required both for definition:changed's fingerprint chain and for
+        # graph modifiers ('+') to expand from the true dependency graph.
         filtered_parsed_models, filtered_execution_order = selector.filter_models(
-            parsed_models, execution_order
+            parsed_models, execution_order, graph=graph, state_backend=state_backend
         )
         logger.info(
             f"\nAfter filtering: {len(filtered_parsed_models)} models selected", extra=_CLI_OUTPUT

--- a/t4t/observability/logging_setup.py
+++ b/t4t/observability/logging_setup.py
@@ -80,6 +80,15 @@ GATED_LOGGER_NAMES: frozenset[str] = frozenset(
         "t4t.engine.executors.model_executor",
         "t4t.testing.executors.model_test_executor",
         "t4t.testing.executors.function_test_executor",
+        # #14: definition:changed's "no baseline" warning and run:failed's
+        # "no previous run" warning are curated, user-facing output (see the
+        # issue's usage example) -- tagged extra={"cli_output": True} at
+        # their call sites in t4t/cli/selection.py. That module also has no
+        # other logging today, but it's gated (not added to
+        # CLI_OUTPUT_LOGGER_NAMES) on the same principle as the modules
+        # above: only explicitly-tagged records should ever reach stdout
+        # from here, not anything logged in the future without a marker.
+        "t4t.cli.selection",
     }
 )
 

--- a/t4t/state/__init__.py
+++ b/t4t/state/__init__.py
@@ -10,7 +10,7 @@ from t4t.state.manifest import (
     results_to_manifest,
     utc_now_iso,
 )
-from t4t.state.retry import compute_retry_set, prepare_retry_select_patterns
+from t4t.state.retry import compute_retry_set
 
 __all__ = [
     "SCHEMA_VERSION",
@@ -23,5 +23,4 @@ __all__ = [
     "results_to_manifest",
     "utc_now_iso",
     "compute_retry_set",
-    "prepare_retry_select_patterns",
 ]

--- a/t4t/state/graph_walk.py
+++ b/t4t/state/graph_walk.py
@@ -1,0 +1,61 @@
+"""Generic transitive-closure walks over a project dependency graph.
+
+Extracted so there is exactly **one** implementation of "walk the dependency
+graph transitively from a set of seed models", shared by:
+
+- `t4t.state.retry.compute_retry_set` (#18's ``--retry``: failed models +
+  their transitive downstream dependents).
+- `t4t.cli.selection` (#14's graph modifiers -- leading ``+`` for upstream,
+  trailing ``+`` for downstream -- and, via ``--retry`` becoming sugar for
+  ``--select run:failed+``, the same downstream walk as above).
+
+Both directions use the same dependency-graph shape produced by
+`ProjectParser.build_dependency_graph()` / `ParserOrchestrator
+.get_execution_order()`: a dict with ``"dependencies"`` (model -> its direct
+upstream deps) and ``"dependents"`` (model -> its direct downstream
+dependents) keys. Test nodes (``test:``-prefixed) are never stepped into --
+they aren't models, and neither `--retry` nor #14's modifiers select them.
+"""
+
+from typing import Any
+
+_TEST_NODE_PREFIX = "test:"
+
+
+def _walk(adjacency: dict[str, list[str]], seeds: set[str]) -> set[str]:
+    """BFS over `adjacency` starting from `seeds`; returns reachable nodes,
+    excluding the seeds themselves and any `test:`-prefixed node."""
+    out: set[str] = set()
+    visited = set(seeds)
+    stack = list(seeds)
+    while stack:
+        n = stack.pop()
+        for neighbor in adjacency.get(n, []):
+            if neighbor.startswith(_TEST_NODE_PREFIX):
+                continue
+            if neighbor in visited:
+                continue
+            visited.add(neighbor)
+            out.add(neighbor)
+            stack.append(neighbor)
+    return out
+
+
+def transitive_downstream(graph: dict[str, Any], seeds: set[str]) -> set[str]:
+    """All transitive dependents (children) of `seeds` -- i.e. everything
+    that depends, directly or indirectly, on any model in `seeds`.
+
+    Does not include the seeds themselves.
+    """
+    dependents: dict[str, list[str]] = graph.get("dependents") or {}
+    return _walk(dependents, seeds)
+
+
+def transitive_upstream(graph: dict[str, Any], seeds: set[str]) -> set[str]:
+    """All transitive dependencies (ancestors) of `seeds` -- i.e. everything
+    that any model in `seeds` depends on, directly or indirectly.
+
+    Does not include the seeds themselves.
+    """
+    dependencies: dict[str, list[str]] = graph.get("dependencies") or {}
+    return _walk(dependencies, seeds)

--- a/t4t/state/retry.py
+++ b/t4t/state/retry.py
@@ -1,15 +1,21 @@
 """
 Compute which models to re-run from a stored manifest (failed + downstream + upstream-skipped).
+
+Note (#14): the CLI no longer calls `compute_retry_set` directly -- `--retry`
+is now sugar for `--select run:failed+`, resolved by `t4t.cli.selection`
+using the same `t4t.state.graph_walk.transitive_downstream` this module
+uses below (single implementation of the graph walk, see that module's
+docstring). `compute_retry_set` is kept here as a tested, standalone utility
+(and because its seed set -- failed *and* upstream-skipped nodes -- is a
+useful building block on its own), but production selection goes through
+`ModelSelector` now.
 """
 
 import logging
-from pathlib import Path
 from typing import Any
 
-from t4t.compiler import compile_project
-from t4t.executor_helpers.shared_helpers import validate_compile_results
-from t4t.state.backend import LocalStateBackend
-from t4t.state.manifest import SCHEMA_VERSION, RunManifest
+from t4t.state.graph_walk import transitive_downstream
+from t4t.state.manifest import RunManifest
 
 logger = logging.getLogger(__name__)
 
@@ -26,24 +32,6 @@ def _is_upstream_skip(reason: str | None) -> bool:
     if reason == "depends_on_failed":
         return True
     return any(reason.startswith(p) for p in _UPSTREAM_SKIP_PREFIXES)
-
-
-def _transitive_downstream(graph: dict[str, Any], seeds: set[str]) -> set[str]:
-    dependents: dict[str, list[str]] = graph.get("dependents") or {}
-    out: set[str] = set()
-    visited = set(seeds)
-    stack = list(seeds)
-    while stack:
-        n = stack.pop()
-        for d in dependents.get(n, []):
-            if d.startswith("test:"):
-                continue
-            if d in visited:
-                continue
-            visited.add(d)
-            out.add(d)
-            stack.append(d)
-    return out
 
 
 def compute_retry_set(manifest: RunManifest, graph: dict[str, Any]) -> set[str]:
@@ -67,7 +55,7 @@ def compute_retry_set(manifest: RunManifest, graph: dict[str, Any]) -> set[str]:
             upstream_skipped.add(node.name)
 
     seeds = failed | upstream_skipped
-    downstream = _transitive_downstream(graph, seeds)
+    downstream = transitive_downstream(graph, seeds)
     raw = seeds | downstream
 
     valid: set[str] = set()
@@ -80,44 +68,3 @@ def compute_retry_set(manifest: RunManifest, graph: dict[str, Any]) -> set[str]:
                 name,
             )
     return valid
-
-
-def prepare_retry_select_patterns(
-    project_folder: str,
-    connection_config: dict[str, Any],
-    variables: dict[str, Any] | None,
-    project_config: dict[str, Any] | None,
-    env_name: str | None = None,
-) -> list[str]:
-    """
-    Compile the project, load the latest manifest, return model names to pass as --select patterns.
-
-    Only considers runs from the same environment (env-scoped state).
-
-    Raises:
-        ValueError: with a user-facing message when retry cannot proceed
-    """
-    compile_results = compile_project(
-        project_folder=project_folder,
-        connection_config=connection_config,
-        variables=variables,
-        project_config=project_config,
-    )
-    graph, _, _ = validate_compile_results(compile_results)
-    backend = LocalStateBackend(Path(project_folder) / "output", env_name=env_name)
-    manifest = backend.read_latest()
-    if manifest is None:
-        raise ValueError(
-            "No previous run manifest found under output/. Run `t4t run` or `t4t build` first."
-        )
-    if manifest.schema_version != SCHEMA_VERSION:
-        raise ValueError(
-            f"Stored run manifest uses schema version {manifest.schema_version}; "
-            f"this t4t expects {SCHEMA_VERSION}. Delete output/last_run.json or upgrade t4t."
-        )
-    retry_set = compute_retry_set(manifest, graph)
-    if not retry_set:
-        raise ValueError(
-            "Nothing to retry: the last run had no failed models or downstream-skipped models."
-        )
-    return sorted(retry_set)

--- a/tests/cli/test_definition_selection_e2e.py
+++ b/tests/cli/test_definition_selection_e2e.py
@@ -1,0 +1,180 @@
+"""#14's acceptance test (the merge gate) -- the seven cases from the
+issue's "Acceptance criteria" section, run against a real project
+(tests/fixtures/definition_selection_project/) via `CliRunner` and real
+`t4t run` invocations, not mocked selection logic.
+
+Fixture project (`models/e2e/`):
+
+- `leaf_changed` (Python, `tags=["nightly"]`, no dependents) -- the sole
+  Python model in the project. Kept as the *only* Python model
+  deliberately: t4t's Python-model shared-import detection (#13) diffs
+  `sys.modules` once per whole `t4t` invocation, which means editing one
+  Python model's file can, as a documented v1 limitation (see
+  docs/user-guide/fingerprinting.md), spuriously mark an *unrelated*
+  second Python model as changed too (over-attribution, not a bug this
+  issue needs to fix). A single Python model sidesteps that limitation
+  entirely while still exercising real tag-carrying model support (SQL
+  models cannot carry `tags` today -- verified empirically: SQL-comment
+  metadata's schema drops the field).
+- `chain_root` -> `chain_mid` -> `chain_leaf` (SQL): a 3-model dependency
+  chain, used for the downstream-closure case (2).
+- `unrelated` (SQL, untagged, never edited): proves selection doesn't leak
+  to models outside the selected set/closure.
+- `union_target` (SQL, untagged): the "changed but not tagged" model used
+  to tell union (case 6) and intersection (case 7) apart.
+- `fail_target` (SQL, always references a nonexistent table -> always
+  fails execution, never edited): proves `definition:changed` and
+  `run:failed` are orthogonal (cases 3-4).
+- `ok_b`, `ok_c` (SQL, always succeed, never edited): the other two
+  "attempted regardless of outcome" models for case 3.
+
+Sequencing note: every `t4t run` invocation -- even a `--select` that
+matches zero models -- persists a new "latest run" manifest (last_run.json/
+runs.sqlite), which is what `run:failed`/`--retry` read. So the `run:failed`
+(case 4) and `--retry` checks must run *before* any other invocation that
+would overwrite that manifest with the narrower "0 models selected" or
+"3-model" runs cases 3/1/2 make -- see the ordering below, which checks
+run:failed/--retry immediately after the baseline run, then definition:
+changed (case 3), then cases 1/2/6/7 in sequence, each consuming the
+"changed" state its own edit created (each edit is a *new* SQL/source
+change relative to whatever baseline the previous case's run just wrote).
+"""
+
+import shutil
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from t4t.cli.main import app
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "definition_selection_project"
+
+ALL_MODELS = {
+    "e2e.leaf_changed",
+    "e2e.chain_root",
+    "e2e.chain_mid",
+    "e2e.chain_leaf",
+    "e2e.unrelated",
+    "e2e.union_target",
+    "e2e.fail_target",
+    "e2e.ok_b",
+    "e2e.ok_c",
+}
+
+
+def _project(tmp_path: Path, name: str = "proj") -> Path:
+    dest = tmp_path / name
+    shutil.copytree(FIXTURE, dest)
+    (dest / "data").mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+def _run(runner: CliRunner, project: Path, *extra_args: str):
+    result = runner.invoke(app, ["run", str(project), *extra_args], catch_exceptions=False)
+    assert result.exit_code == 0, result.stdout + result.stderr
+    return result.stdout + result.stderr
+
+
+def _bump_leaf_changed(project: Path, value: int) -> None:
+    path = project / "models" / "e2e" / "leaf_changed.py"
+    path.write_text(
+        f'@model(table_name="leaf_changed", tags=["nightly"])  # noqa: F821\n'
+        f"def leaf_changed():\n"
+        f'    return "SELECT {value} AS id"\n',
+        encoding="utf-8",
+    )
+
+
+def _bump_sql(path: Path, value: int) -> None:
+    path.write_text(f"SELECT {value} AS id\n", encoding="utf-8")
+
+
+class TestDefinitionSelectionAcceptance:
+    def test_seven_case_acceptance(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        project = _project(tmp_path)
+
+        # --- Baseline run: all 9 models attempted, fail_target fails,
+        # 8 others succeed. Establishes the fingerprint baseline for every
+        # model (case 3's premise) and the run manifest run:failed/--retry
+        # read (case 4's premise). ---
+        out0 = _run(runner, project)
+        assert "8 tables" in out0  # 8 succeeded
+        assert "Failed: 1 table" in out0  # fail_target
+
+        # === Case 4 (checked first -- see module docstring on manifest
+        # ordering): run:failed selects exactly the failed model, even
+        # though its definition never changed. ===
+        out_failed = _run(runner, project, "--select", "run:failed")
+        assert "Filtered to 1 models (from 9 total)" in out_failed
+        assert "e2e.fail_target" in out_failed
+
+        # --retry is sugar for --select run:failed+ -- same result here
+        # (fail_target has no downstream dependents, so the '+' adds
+        # nothing new).
+        out_retry = _run(runner, project, "--retry")
+        assert "Filtered to 1 models (from 9 total)" in out_retry
+        assert "e2e.fail_target" in out_retry
+
+        # === Case 3: on the run right after the failure, definition:changed
+        # selects NONE of fail_target/ok_b/ok_c (or anyone else) -- the
+        # baseline update is per-model-attempted, independent of success/
+        # failure, per #14's design decision. ===
+        out_none_changed = _run(runner, project, "--select", "definition:changed")
+        assert "No models matched the selection criteria" in out_none_changed
+
+        # === Case 1: change one model's SQL (leaf_changed, a leaf with no
+        # dependents); definition:changed executes only that model. ===
+        _bump_leaf_changed(project, 2)
+        out_case1 = _run(runner, project, "--select", "definition:changed")
+        assert "Filtered to 1 models (from 9 total)" in out_case1
+        assert "Filtered execution order: e2e.leaf_changed" in out_case1
+
+        # === Case 2: definition:changed+ selects the changed model AND its
+        # full downstream closure; unrelated/upstream models do not run. ===
+        _bump_sql(project / "models" / "e2e" / "chain_root.sql", 2)
+        out_case2 = _run(runner, project, "--select", "definition:changed+")
+        assert "Filtered to 3 models (from 9 total)" in out_case2
+        assert (
+            "Filtered execution order: e2e.chain_root -> e2e.chain_mid -> e2e.chain_leaf"
+            in out_case2
+        )
+
+        # === Case 6: union -- definition:changed OR tag:nightly selects
+        # both the newly-changed leaf_changed and the newly-changed,
+        # untagged union_target (matches tag only) plus leaf_changed
+        # (matches both) -- i.e. the union of the two selectors' matches,
+        # not their intersection. ===
+        _bump_leaf_changed(project, 3)
+        _bump_sql(project / "models" / "e2e" / "union_target.sql", 2)
+        out_case6 = _run(
+            runner, project, "--select", "definition:changed", "--select", "tag:nightly"
+        )
+        assert "Filtered to 2 models (from 9 total)" in out_case6
+        assert "e2e.leaf_changed" in out_case6
+        assert "e2e.union_target" in out_case6
+
+        # === Case 7: intersection (comma, no spaces) -- only leaf_changed
+        # (changed AND tagged nightly) is selected; union_target is changed
+        # but not tagged, so it's excluded here despite being included in
+        # case 6's union above -- proving AND, not another OR. ===
+        _bump_leaf_changed(project, 4)
+        out_case7 = _run(runner, project, "--select", "definition:changed,tag:nightly")
+        assert "Filtered to 1 models (from 9 total)" in out_case7
+        assert "Filtered execution order: e2e.leaf_changed" in out_case7
+        assert (
+            "e2e.union_target" not in out_case7.split("Filtered execution order:")[1].split("\n")[0]
+        )
+
+    def test_case_5_first_run_no_baseline_selects_all_with_warning(self, tmp_path: Path) -> None:
+        """Case 5: first run ever, no persisted baseline -- definition:changed
+        selects ALL models, with a warning printed (fail-open)."""
+        runner = CliRunner()
+        project = _project(tmp_path, name="fresh")
+
+        out = _run(runner, project, "--select", "definition:changed")
+
+        assert "No baseline" in out
+        assert "dev" in out
+        assert f"Filtered to {len(ALL_MODELS)} models (from {len(ALL_MODELS)} total)" in out

--- a/tests/cli/test_retry_sugar.py
+++ b/tests/cli/test_retry_sugar.py
@@ -1,0 +1,50 @@
+"""#14 step 8: --retry is sugar for --select run:failed+ -- one
+implementation, flag is an alias.
+
+Verifies both spellings produce identical selection on the same failure
+scenario (two independent copies of the same project, since a run mutates
+persisted state). This complements tests/cli/test_retry_integration.py
+(which only exercises --retry) by proving --select run:failed+ is not just
+parseable but behaviorally identical, end to end, on a real project.
+"""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from t4t.cli.main import app
+
+from .test_retry_integration import _write_retry_chain_project
+
+
+class TestRetrySugarEquivalence:
+    def test_retry_flag_and_explicit_select_produce_same_filtered_count(
+        self, tmp_path: Path
+    ) -> None:
+        runner = CliRunner()
+
+        # Two independent copies of the same failure scenario -- a run
+        # mutates persisted state, so --retry and --select run:failed+
+        # can't share one project directory.
+        project_a = _write_retry_chain_project(tmp_path / "proj_a")
+        project_b = _write_retry_chain_project(tmp_path / "proj_b")
+
+        # Baseline (failing) run on both.
+        r_a0 = runner.invoke(app, ["run", str(project_a)], catch_exceptions=False)
+        assert r_a0.exit_code == 0, r_a0.stdout + r_a0.stderr
+        r_b0 = runner.invoke(app, ["run", str(project_b)], catch_exceptions=False)
+        assert r_b0.exit_code == 0, r_b0.stdout + r_b0.stderr
+
+        # A: --retry: B: --select run:failed+
+        r_a1 = runner.invoke(app, ["run", str(project_a), "--retry"], catch_exceptions=False)
+        r_b1 = runner.invoke(
+            app, ["run", str(project_b), "--select", "run:failed+"], catch_exceptions=False
+        )
+
+        assert r_a1.exit_code == 0, r_a1.stdout + r_a1.stderr
+        assert r_b1.exit_code == 0, r_b1.stdout + r_b1.stderr
+
+        out_a = r_a1.stdout + r_a1.stderr
+        out_b = r_b1.stdout + r_b1.stderr
+        assert "Filtered to 3 models" in out_a
+        assert "Filtered to 3 models" in out_b

--- a/tests/cli/test_selection_groups.py
+++ b/tests/cli/test_selection_groups.py
@@ -1,0 +1,131 @@
+"""Unit tests for #14 steps 1-3: OR-of-AND-groups restructuring.
+
+- Step 1: split each `--select` value on comma into an AND-group; repeated
+  `--select` values OR across groups. Regression: no-comma, single-token
+  behavior (pre-#14) is unchanged -- see tests/cli/test_selection.py for the
+  full byte-for-byte regression suite; this file adds the *new* comma
+  behavior only.
+- Step 2: `definition:`/`run:`/`tag:`/plain-name atomic condition
+  recognition, including inside a comma AND-group.
+- Step 3: intersection evaluation -- a model matching only one of two
+  comma-joined conditions is not selected.
+"""
+
+from t4t.cli.selection import (
+    DefinitionChangedCondition,
+    ModelSelector,
+    NameCondition,
+    RunFailedCondition,
+    SelectionParseError,
+    TagCondition,
+)
+
+
+def _model(tags: list[str] | None = None) -> dict:
+    return {"model_metadata": {"metadata": {"tags": tags or []}}}
+
+
+class TestGroupParsing:
+    """Step 1: each --select value -> one AND-group; degenerate single-token
+    case matches pre-#14 (one condition per group)."""
+
+    def test_single_token_is_one_group_one_condition(self):
+        selector = ModelSelector(select_patterns=["my_model"])
+        assert len(selector.select_groups) == 1
+        assert len(selector.select_groups[0].conditions) == 1
+
+    def test_comma_splits_into_and_group(self):
+        selector = ModelSelector(select_patterns=["definition:changed,tag:nightly"])
+        assert len(selector.select_groups) == 1
+        group = selector.select_groups[0]
+        assert len(group.conditions) == 2
+
+    def test_repeated_select_values_are_separate_or_groups(self):
+        selector = ModelSelector(select_patterns=["a", "tag:nightly"])
+        assert len(selector.select_groups) == 2
+
+
+class TestAtomicConditionRecognition:
+    """Step 2."""
+
+    def test_tag_condition_type(self):
+        selector = ModelSelector(select_patterns=["tag:nightly"])
+        cond = selector.select_groups[0].conditions[0]
+        assert isinstance(cond, TagCondition)
+        assert cond.tag == "nightly"
+
+    def test_name_condition_type(self):
+        selector = ModelSelector(select_patterns=["my_model"])
+        cond = selector.select_groups[0].conditions[0]
+        assert isinstance(cond, NameCondition)
+        assert cond.pattern == "my_model"
+
+    def test_definition_changed_condition_type(self):
+        selector = ModelSelector(select_patterns=["definition:changed"])
+        cond = selector.select_groups[0].conditions[0]
+        assert isinstance(cond, DefinitionChangedCondition)
+
+    def test_run_failed_condition_type(self):
+        selector = ModelSelector(select_patterns=["run:failed"])
+        cond = selector.select_groups[0].conditions[0]
+        assert isinstance(cond, RunFailedCondition)
+
+    def test_comma_group_has_two_distinct_condition_types(self):
+        selector = ModelSelector(select_patterns=["definition:changed,tag:nightly"])
+        conditions = selector.select_groups[0].conditions
+        types = {type(c) for c in conditions}
+        assert types == {DefinitionChangedCondition, TagCondition}
+
+    def test_unsupported_definition_value_raises(self):
+        import pytest
+
+        with pytest.raises(SelectionParseError):
+            ModelSelector(select_patterns=["definition:bogus"])
+
+    def test_unsupported_run_value_raises(self):
+        import pytest
+
+        with pytest.raises(SelectionParseError):
+            ModelSelector(select_patterns=["run:bogus"])
+
+    def test_data_prefix_reserved_raises(self):
+        import pytest
+
+        with pytest.raises(SelectionParseError):
+            ModelSelector(select_patterns=["data:changed"])
+
+
+class TestIntersectionEvaluation:
+    """Step 3: a model must satisfy every condition in a comma AND-group."""
+
+    def test_model_matching_only_one_of_two_conditions_not_selected(self):
+        selector = ModelSelector(select_patterns=["tag:nightly,tag:analytics"])
+        nightly_only = _model(tags=["nightly"])
+        both = _model(tags=["nightly", "analytics"])
+        analytics_only = _model(tags=["analytics"])
+
+        assert selector.is_selected("m.nightly_only", nightly_only) is False
+        assert selector.is_selected("m.both", both) is True
+        assert selector.is_selected("m.analytics_only", analytics_only) is False
+
+    def test_name_and_tag_intersection(self):
+        selector = ModelSelector(select_patterns=["my_model,tag:nightly"])
+        matches_name_only = _model(tags=[])
+        matches_both = _model(tags=["nightly"])
+
+        assert selector.is_selected("my_model", matches_name_only) is False
+        assert selector.is_selected("my_model", matches_both) is True
+        # Right tag, wrong name -> still not selected (AND, not OR).
+        assert selector.is_selected("other_model", matches_both) is False
+
+    def test_union_across_repeated_select_still_or(self):
+        """Regression: multiple --select flags still OR (pre-#14 behavior),
+        only comma-within-one-value is new AND behavior."""
+        selector = ModelSelector(select_patterns=["tag:nightly", "tag:analytics"])
+        nightly_only = _model(tags=["nightly"])
+        analytics_only = _model(tags=["analytics"])
+        neither = _model(tags=[])
+
+        assert selector.is_selected("m1", nightly_only) is True
+        assert selector.is_selected("m2", analytics_only) is True
+        assert selector.is_selected("m3", neither) is False

--- a/tests/cli/test_selection_modifiers.py
+++ b/tests/cli/test_selection_modifiers.py
@@ -1,0 +1,94 @@
+"""Unit tests for #14 step 7: graph modifiers (leading/trailing `+`).
+
+Fixture DAG throughout: A -> B -> C (A is upstream of B, B is upstream of
+C). Modifiers are stripped from the *whole* --select value before the
+comma-split and applied to the group's evaluated result -- never to an
+individual comma-separated token (see t4t/cli/selection.py's module
+docstring and the issue's "Design decisions").
+"""
+
+from t4t.cli.selection import ModelSelector
+
+
+def _graph() -> dict:
+    return {
+        "execution_order": ["s.a", "s.b", "s.c"],
+        "dependencies": {"s.a": [], "s.b": ["s.a"], "s.c": ["s.b"]},
+        "dependents": {"s.a": ["s.b"], "s.b": ["s.c"], "s.c": []},
+    }
+
+
+def _models(tags: dict[str, list[str]] | None = None) -> dict:
+    tags = tags or {}
+    return {
+        name: {"model_metadata": {"metadata": {"tags": tags.get(name, [])}}}
+        for name in ("s.a", "s.b", "s.c")
+    }
+
+
+class TestNameBasedModifiers:
+    def test_trailing_plus_expands_downstream(self):
+        selector = ModelSelector(select_patterns=["s.a+"])
+        filtered, _ = selector.filter_models(_models(), graph=_graph())
+        assert set(filtered.keys()) == {"s.a", "s.b", "s.c"}
+
+    def test_leading_plus_expands_upstream(self):
+        selector = ModelSelector(select_patterns=["+s.c"])
+        filtered, _ = selector.filter_models(_models(), graph=_graph())
+        assert set(filtered.keys()) == {"s.a", "s.b", "s.c"}
+
+    def test_middle_node_downstream_only(self):
+        selector = ModelSelector(select_patterns=["s.b+"])
+        filtered, _ = selector.filter_models(_models(), graph=_graph())
+        assert set(filtered.keys()) == {"s.b", "s.c"}
+        assert "s.a" not in filtered
+
+    def test_no_modifier_is_exact_match_only(self):
+        selector = ModelSelector(select_patterns=["s.b"])
+        filtered, _ = selector.filter_models(_models(), graph=_graph())
+        assert set(filtered.keys()) == {"s.b"}
+
+    def test_both_modifiers_together(self):
+        selector = ModelSelector(select_patterns=["+s.b+"])
+        filtered, _ = selector.filter_models(_models(), graph=_graph())
+        assert set(filtered.keys()) == {"s.a", "s.b", "s.c"}
+
+
+class TestTagBasedModifierWithIntersection:
+    """`"definition:changed,tag:nightly+"` style: modifier wraps the whole
+    comma-AND-group's result, not an individual token."""
+
+    def test_intersection_then_downstream_expansion(self):
+        # Only s.a is tagged nightly; select "tag:nightly+" -> {s.a} then
+        # downstream expand to include s.b, s.c.
+        models = _models(tags={"s.a": ["nightly"]})
+        selector = ModelSelector(select_patterns=["tag:nightly+"])
+        filtered, _ = selector.filter_models(models, graph=_graph())
+        assert set(filtered.keys()) == {"s.a", "s.b", "s.c"}
+
+    def test_intersection_group_base_set_before_expansion(self):
+        # s.b and s.c both tagged nightly, but only s.c matches
+        # "tag:nightly,tag:other" (AND) -> base={s.c}, then + expands
+        # nothing further downstream of s.c (leaf).
+        models = _models(tags={"s.b": ["nightly"], "s.c": ["nightly", "other"]})
+        selector = ModelSelector(select_patterns=["tag:nightly,tag:other+"])
+        filtered, _ = selector.filter_models(models, graph=_graph())
+        assert set(filtered.keys()) == {"s.c"}
+
+
+class TestModifiersRequireGraph:
+    def test_modifier_without_graph_raises(self):
+        from t4t.cli.selection import SelectionContextError
+
+        selector = ModelSelector(select_patterns=["s.a+"])
+        import pytest
+
+        with pytest.raises(SelectionContextError):
+            selector.filter_models(_models())  # no graph= passed
+
+
+class TestExcludeWithModifiers:
+    def test_exclude_downstream_of_a_removes_b_and_c(self):
+        selector = ModelSelector(select_patterns=None, exclude_patterns=["s.a+"])
+        filtered, _ = selector.filter_models(_models(), graph=_graph())
+        assert set(filtered.keys()) == set()

--- a/tests/cli/test_selection_state.py
+++ b/tests/cli/test_selection_state.py
@@ -1,0 +1,199 @@
+"""Unit tests for #14 steps 4-6: definition:changed baseline diff (+
+missing-baseline fail-open) and run:failed.
+
+Uses a small in-memory fake `StateBackend` (satisfies the `StateBackend`
+Protocol) rather than a real `LocalStateBackend`/sqlite file -- these tests
+are about `ModelSelector`'s consumption of #13's fingerprint storage and
+#18's run manifest, not about the storage layer itself (already covered by
+tests/engine/test_fingerprint.py and tests/state/*).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from t4t.cli.selection import ModelSelector, SelectionContextError
+from t4t.engine.fingerprint import FINGERPRINT_SPEC_VERSION, compute_project_fingerprints
+from t4t.state.fingerprint import StoredFingerprint
+from t4t.state.manifest import NodeResult, RunManifest
+
+
+class FakeStateBackend:
+    """Minimal in-memory StateBackend for selection tests."""
+
+    def __init__(self) -> None:
+        self._fingerprints: dict[str, StoredFingerprint] = {}
+        self._latest: RunManifest | None = None
+
+    def append_run(self, manifest: RunManifest) -> None:
+        self._latest = manifest
+
+    def read_latest(self) -> RunManifest | None:
+        return self._latest
+
+    def save_fingerprint(
+        self,
+        model_name: str,
+        sql_hash: str,
+        config_hash: str,
+        fingerprint: str,
+        fingerprint_spec_version: int,
+    ) -> None:
+        self._fingerprints[model_name] = StoredFingerprint(
+            model_name=model_name,
+            sql_hash=sql_hash,
+            config_hash=config_hash,
+            fingerprint=fingerprint,
+            fingerprint_spec_version=fingerprint_spec_version,
+        )
+
+    def read_fingerprint(self, model_name: str) -> StoredFingerprint | None:
+        return self._fingerprints.get(model_name)
+
+
+def _model(path: Path, sql: str) -> dict:
+    path.write_text(sql, encoding="utf-8")
+    return {
+        "model_metadata": {
+            "file_path": str(path),
+            "function_name": None,
+            "metadata": {},
+        }
+    }
+
+
+def _manifest(nodes: list[NodeResult]) -> RunManifest:
+    return RunManifest(
+        schema_version=2,
+        t4t_version="0.1.0",
+        run_id="r1",
+        command="run",
+        started_at="t0",
+        finished_at="t1",
+        project_root="/p",
+        config_hash=None,
+        vars_hash=None,
+        execution_order=[n.name for n in nodes],
+        nodes=nodes,
+        functions=[],
+    )
+
+
+class TestDefinitionChangedBaselineDiff:
+    """Step 4."""
+
+    def _graph(self, deps: dict[str, list[str]]) -> dict:
+        order = list(deps.keys())
+        return {"execution_order": order, "dependencies": deps, "dependents": {}}
+
+    def test_matching_baseline_not_selected_mismatch_is(self, tmp_path: Path) -> None:
+        models = {
+            "s.a": _model(tmp_path / "a.sql", "SELECT 1\n"),
+            "s.b": _model(tmp_path / "b.sql", "SELECT 2\n"),
+        }
+        graph = self._graph({"s.a": [], "s.b": []})
+        current = compute_project_fingerprints(models, graph)
+
+        backend = FakeStateBackend()
+        # Baseline for s.a matches current -> not changed.
+        backend.save_fingerprint(
+            "s.a",
+            current["s.a"].sql_hash,
+            current["s.a"].config_hash,
+            current["s.a"].fingerprint,
+            FINGERPRINT_SPEC_VERSION,
+        )
+        # Baseline for s.b is stale (different fingerprint) -> changed.
+        backend.save_fingerprint(
+            "s.b", "old_sql_hash", "old_config_hash", "old_fingerprint", FINGERPRINT_SPEC_VERSION
+        )
+
+        selector = ModelSelector(select_patterns=["definition:changed"], state_backend=backend)
+        filtered, _ = selector.filter_models(models, graph=graph)
+
+        assert "s.a" not in filtered
+        assert "s.b" in filtered
+
+    def test_definition_changed_without_context_raises(self, tmp_path: Path) -> None:
+        models = {"s.a": _model(tmp_path / "a.sql", "SELECT 1\n")}
+        selector = ModelSelector(select_patterns=["definition:changed"])
+        with pytest.raises(SelectionContextError):
+            selector.is_selected("s.a", models["s.a"])
+
+
+class TestMissingBaselineFailOpen:
+    """Step 5."""
+
+    def test_empty_baseline_store_selects_all_as_changed(self, tmp_path: Path) -> None:
+        models = {
+            "s.a": _model(tmp_path / "a.sql", "SELECT 1\n"),
+            "s.b": _model(tmp_path / "b.sql", "SELECT 2\n"),
+        }
+        graph = {
+            "execution_order": ["s.a", "s.b"],
+            "dependencies": {"s.a": [], "s.b": []},
+            "dependents": {},
+        }
+        backend = FakeStateBackend()  # no fingerprints stored at all
+
+        selector = ModelSelector(select_patterns=["definition:changed"], state_backend=backend)
+        filtered, _ = selector.filter_models(models, graph=graph)
+
+        assert set(filtered.keys()) == {"s.a", "s.b"}
+
+    def test_missing_baseline_emits_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The missing-baseline warning is curated CLI output (tagged
+        `extra={"cli_output": True}`, see t4t/cli/selection.py and
+        GATED_LOGGER_NAMES in t4t/observability/logging_setup.py) -- it is
+        deliberately excluded from any *other* root handler (including
+        pytest's caplog capture handler, via `_ExcludeCuratedFilter`) to
+        avoid double-printing, so it must be asserted on stdout via `capsys`,
+        not `caplog`.
+        """
+        models = {"s.a": _model(tmp_path / "a.sql", "SELECT 1\n")}
+        graph = {"execution_order": ["s.a"], "dependencies": {"s.a": []}, "dependents": {}}
+        backend = FakeStateBackend()
+
+        selector = ModelSelector(
+            select_patterns=["definition:changed"], state_backend=backend, env_name="dev"
+        )
+        selector.filter_models(models, graph=graph)
+
+        out = capsys.readouterr().out
+        assert "baseline" in out.lower()
+        assert "dev" in out
+
+
+class TestRunFailed:
+    """Step 6."""
+
+    def test_mixed_statuses_selects_only_failed(self) -> None:
+        manifest = _manifest(
+            [
+                NodeResult(name="s.a", status="success", row_count=1),
+                NodeResult(name="s.b", status="failed", error="boom"),
+                NodeResult(name="s.c", status="skipped", skip_reason="upstream_failed:s.b"),
+            ]
+        )
+        backend = FakeStateBackend()
+        backend.append_run(manifest)
+
+        models = {"s.a": {}, "s.b": {}, "s.c": {}}
+        selector = ModelSelector(select_patterns=["run:failed"], state_backend=backend)
+        filtered, _ = selector.filter_models(models)
+
+        assert set(filtered.keys()) == {"s.b"}
+
+    def test_no_manifest_selects_nothing(self) -> None:
+        backend = FakeStateBackend()
+        models = {"s.a": {}}
+        selector = ModelSelector(select_patterns=["run:failed"], state_backend=backend)
+        filtered, _ = selector.filter_models(models)
+        assert filtered == {}
+
+    def test_run_failed_without_context_raises(self) -> None:
+        selector = ModelSelector(select_patterns=["run:failed"])
+        with pytest.raises(SelectionContextError):
+            selector.is_selected("s.a", {})

--- a/tests/fixtures/definition_selection_project/models/e2e/chain_leaf.sql
+++ b/tests/fixtures/definition_selection_project/models/e2e/chain_leaf.sql
@@ -1,0 +1,1 @@
+SELECT * FROM chain_mid

--- a/tests/fixtures/definition_selection_project/models/e2e/chain_mid.sql
+++ b/tests/fixtures/definition_selection_project/models/e2e/chain_mid.sql
@@ -1,0 +1,1 @@
+SELECT * FROM chain_root

--- a/tests/fixtures/definition_selection_project/models/e2e/chain_root.sql
+++ b/tests/fixtures/definition_selection_project/models/e2e/chain_root.sql
@@ -1,0 +1,1 @@
+SELECT 1 AS id

--- a/tests/fixtures/definition_selection_project/models/e2e/fail_target.sql
+++ b/tests/fixtures/definition_selection_project/models/e2e/fail_target.sql
@@ -1,0 +1,1 @@
+SELECT * FROM __nonexistent_table_e2e__

--- a/tests/fixtures/definition_selection_project/models/e2e/leaf_changed.py
+++ b/tests/fixtures/definition_selection_project/models/e2e/leaf_changed.py
@@ -1,0 +1,3 @@
+@model(table_name="leaf_changed", tags=["nightly"])  # noqa: F821
+def leaf_changed():
+    return "SELECT 1 AS id"

--- a/tests/fixtures/definition_selection_project/models/e2e/ok_b.sql
+++ b/tests/fixtures/definition_selection_project/models/e2e/ok_b.sql
@@ -1,0 +1,1 @@
+SELECT 1 AS id

--- a/tests/fixtures/definition_selection_project/models/e2e/ok_c.sql
+++ b/tests/fixtures/definition_selection_project/models/e2e/ok_c.sql
@@ -1,0 +1,1 @@
+SELECT 1 AS id

--- a/tests/fixtures/definition_selection_project/models/e2e/union_target.sql
+++ b/tests/fixtures/definition_selection_project/models/e2e/union_target.sql
@@ -1,0 +1,1 @@
+SELECT 1 AS id

--- a/tests/fixtures/definition_selection_project/models/e2e/unrelated.sql
+++ b/tests/fixtures/definition_selection_project/models/e2e/unrelated.sql
@@ -1,0 +1,1 @@
+SELECT 1 AS id

--- a/tests/fixtures/definition_selection_project/project.toml
+++ b/tests/fixtures/definition_selection_project/project.toml
@@ -1,0 +1,5 @@
+project_folder = "definition_selection_e2e"
+
+[environments.dev.connection]
+type = "duckdb"
+path = "data/definition_selection_e2e.duckdb"


### PR DESCRIPTION
## Summary

Implements #14: the selection language for running only what changed since
the last baseline or what failed last run, with dbt-compatible graph
modifiers and AND/OR combining.

- **`ModelSelector` restructured to OR-of-AND-groups** (`t4t/cli/selection.py`):
  each `--select`/`--exclude` value splits on comma into an AND-group of
  atomic conditions (name pattern, `tag:`, `definition:changed`,
  `run:failed`); repeated flags OR across groups. No-comma, single-token
  behavior is unchanged (full byte-for-byte regression suite in
  `tests/cli/test_selection.py` still passes untouched).
- **`definition:changed`**: diffs #13's stored per-model fingerprint against
  the model's current fingerprint. No baseline for a model -> treated as
  changed (fail-open), with a warning.
- **`run:failed`**: reads `status == "failed"` node names from the last
  persisted `RunManifest`.
- **Graph modifiers** (`+model` = upstream, `model+` = downstream) strip off
  the whole `--select` value before the comma-split and expand the group's
  *result*, never an individual token inside it. New
  `t4t/state/graph_walk.py` holds the one shared transitive-closure
  implementation, used by both this and `t4t/state/retry.py`.
- **`--retry` is now sugar for `--select run:failed+`** -- one
  implementation. Removed the old, separate `prepare_retry_select_patterns`
  CLI-facing mechanism (and its redundant second `compile_project()` call);
  `compute_retry_set` itself is kept (still tested, still a useful
  standalone utility) but production selection no longer calls it.
- **Callers wired**: `execute_models()`/`build_models()` construct an
  env-scoped `LocalStateBackend` and pass the project's full, unfiltered
  `parsed_models`/dependency graph into `ModelSelector.filter_models()` --
  this is what makes `definition:changed`/`run:failed`/modifiers actually
  work end to end in a real run, not just against a fake backend in unit
  tests.
- **Docs**: new `docs/user-guide/selection.md` (full reference, dbt-parity
  called out explicitly), updates to `cli-reference.md`, `fingerprinting.md`,
  the dbt-users guide, and the docs index.

## Implementation steps (issue's ordered list)

1. OR-of-AND-groups restructuring -- done, regression-tested.
2. Atomic condition recognition (`definition:`/`run:`/`tag:`/name) -- done.
3. Intersection evaluation -- done.
4. Baseline diff for `definition:changed` -- done, against #13's actual
   `StateBackend.read_fingerprint`/`read_valid_fingerprint`.
5. Missing-baseline fail-open + warning -- done.
6. `run:failed` -- done.
7. Graph modifiers -- done (unbounded upstream/downstream; no depth-variant
   `+2` syntax, which the issue notes as a future extension, not required
   here, and no acceptance criterion tests it).
8. `--retry` sugar -- done, one implementation.
9. Baseline persistence -- consumed as-is from #13's existing
   `_try_persist_run_manifest`/`store_project_fingerprints` wiring; not
   duplicated.
10. 7-case E2E acceptance test -- done, `tests/cli/test_definition_selection_e2e.py`
    + `tests/fixtures/definition_selection_project/`.
11. Documentation -- done.

## Acceptance criteria (all 7 cases, verified via the E2E test + manual CLI runs)

1. Baseline run, edit one leaf model -> `definition:changed` selects only it. ✅
2. `definition:changed+` on an edited upstream of a 3-model chain -> selects
   the changed model + full downstream closure, nothing else. ✅
3. Partial-failure run (1 fails, 2 succeed, all attempted) -> next
   `definition:changed` selects none of the three. ✅
4. `run:failed` (and `--retry`) on that same next run DOES select the failed
   model -> orthogonal to `definition:changed`. ✅
5. First run ever, no baseline -> `definition:changed` selects all models,
   warning printed. ✅
6. Union: `--select definition:changed --select tag:nightly`. ✅
7. Intersection: `--select "definition:changed,tag:nightly"`, proven
   distinct from case 6's result (excludes a model case 6 included). ✅

## Test plan

- [x] `uv run pytest tests/ -m "not snowflake_e2e" --no-cov`: **1612 passed,
      3 skipped, 23 deselected** (snowflake_e2e requires live credentials,
      excluded the same way CI excludes it).
- [x] `uv run ruff check t4t tests`: clean.
- [x] `uv run ruff format --check t4t tests`: clean.
- [x] Manually verified the full 7-case sequence via direct CLI runs against
      a scratch copy of the fixture project before encoding it as a test
      (documented in the E2E test file's module docstring), including
      discovering and working around two real gotchas: (a) SQL-comment
      model metadata does not carry `tags` through the current parser
      (verified empirically, not assumed) -- the fixture's tagged model is
      a Python model; (b) every `t4t run` invocation, including a
      zero-match `--select`, overwrites the persisted "latest run" manifest
      that `run:failed`/`--retry` read, which drove the acceptance test's
      check ordering.

Closes #14